### PR TITLE
Add some more V1 redirects on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,3 +33,39 @@ for = "/*"
   to = "/token/[_network]/[_token].html"
   status = 200
   force = false
+
+[[redirects]]
+  from = "/dashboard"
+  to = "/"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/currencies"
+  to = "/"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/transactions"
+  to = "/"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/distribution"
+  to = "/"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/activities"
+  to = "/"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/settings"
+  to = "/"
+  status = 200
+  force = false


### PR DESCRIPTION
The current not found message for these is not too bad but better to navigate to root.

<img width="1844" alt="image" src="https://user-images.githubusercontent.com/10894666/180236400-8d413850-8c3b-4df4-a7b5-9124f886c32a.png">