### PR TITLE
Use HTTP 301 over HTTP 200 for V1 redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,35 +37,35 @@ for = "/*"
 [[redirects]]
   from = "/dashboard"
   to = "/"
-  status = 200
+  status = 301
   force = false
 
 [[redirects]]
   from = "/currencies"
   to = "/"
-  status = 200
+  status = 301
   force = false
 
 [[redirects]]
   from = "/transactions"
   to = "/"
-  status = 200
+  status = 301
   force = false
 
 [[redirects]]
   from = "/distribution"
   to = "/"
-  status = 200
+  status = 301
   force = false
 
 [[redirects]]
   from = "/activities"
   to = "/"
-  status = 200
+  status = 301
   force = false
 
 [[redirects]]
   from = "/settings"
   to = "/"
-  status = 200
+  status = 301
   force = false


### PR DESCRIPTION
* stream redirect should be kept to 200 because of client-side routing