### PR TITLE
Add no-op service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,24 @@
+// No-op service worker inspired by: https://stackoverflow.com/a/38980776/6099842
+
+// A simple, no-op service worker that takes immediate control.
+
+self.addEventListener("install", () => {
+  // Skip over the "waiting" lifecycle state, to ensure that our
+  // new service worker is activated immediately, even if there's
+  // another tab open controlled by our older service worker code.
+  self.skipWaiting();
+});
+
+/*
+  self.addEventListener('activate', () => {
+    // Optional: Get a list of all the current open windows/tabs under
+    // our service worker's control, and force them to reload.
+    // This can "unbreak" any open windows/tabs as soon as the new
+    // service worker activates, rather than users having to manually reload.
+    self.clients.matchAll({type: 'window'}).then(windowClients => {
+      windowClients.forEach(windowClient => {
+        windowClient.navigate(windowClient.url);
+      });
+    });
+  });
+  */


### PR DESCRIPTION
To resolve V1 app's service worker requesting `/service-worker.js` and supposedly serving cached data:
<img width="411" alt="image" src="https://user-images.githubusercontent.com/10894666/180246116-73a6c173-79d6-4511-a6aa-0baeda18a1a7.png">

Solution based on: https://stackoverflow.com/a/38980776/6099842