### PR TITLE
Retry longer to try to set Intercom's visitor ID for Sentry

### DIFF
--- a/src/components/SentryContext/SentryContext.tsx
+++ b/src/components/SentryContext/SentryContext.tsx
@@ -63,8 +63,8 @@ const SentryContext: FC = () => {
           }).catch(retry),
         {
           minTimeout: 500,
-          maxTimeout: 2000,
-          retries: 10,
+          maxTimeout: 3000,
+          retries: 20,
         }
       );
     }

--- a/src/features/network/readOnlyFrameworks.ts
+++ b/src/features/network/readOnlyFrameworks.ts
@@ -15,7 +15,7 @@ const readOnlyFrameworks = networks.map((network) => ({
           ),
         }).catch(retry),
       {
-        minTimeout: 1000,
+        minTimeout: 500,
         maxTimeout: 3000,
         retries: 10,
       }


### PR DESCRIPTION
Not sure why the visitor ID can't be fetched for everybody from Intercom: https://sentry.io/organizations/superfluid-finance/issues/3494420122/?environment=production&project=6408985

Could be some blocker plugin; could be some Intercom issue. I don't know -- it's not a critical bug.