### PR TITLE
Remove usage of Cloudflare RPC for ENS

### DIFF
--- a/src/features/ens/ensApi.slice.ts
+++ b/src/features/ens/ensApi.slice.ts
@@ -13,24 +13,9 @@ export const ensApi = createApi({
   baseQuery: fakeBaseQuery(),
   keepUnusedDataFor: 600, // Agressively cache the ENS queries
   endpoints: (builder) => {
-    const mainnetProvider = new ethers.providers.FallbackProvider(
-      [
-        {
-          provider: new ethers.providers.JsonRpcBatchProvider(
-            "https://rpc-endpoints.superfluid.dev/eth-mainnet",
-            "mainnet"
-          ),
-          priority: 1,
-        },
-        {
-          provider: new ethers.providers.JsonRpcBatchProvider(
-            "https://cloudflare-eth.com",
-            "mainnet"
-          ),
-          priority: 2,
-        },
-      ],
-      1
+    const mainnetProvider = new ethers.providers.JsonRpcBatchProvider(
+      "https://rpc-endpoints.superfluid.dev/eth-mainnet",
+      "mainnet"
     );
     return {
       resolveName: builder.query<ResolveNameResult | null, string>({


### PR DESCRIPTION
A lot of RPC errors seem to be related to RPC on Sentry. It's really not a critical piece and only used as a fallback mechanism. I'd remove it for now to reduce spam on Sentry. We can add it back once we have a better grasp of the issues popping up on Sentry.