### PR TITLE
Use hard-coded gas limits for Gnosis Safe

### DIFF
--- a/src/features/index/SubscriptionRow.tsx
+++ b/src/features/index/SubscriptionRow.tsx
@@ -295,7 +295,7 @@ const SubscriptionRow: FC<SubscriptionRowProps> = ({
                             superTokenAddress: subscription.token,
                             userDataBytes: undefined,
                             waitForConfirmation: false,
-                            overrides: await getTransactionOverrides(network),
+                            overrides: await getTransactionOverrides("Approve Index Subscription", network),
                           });
                         }}
                       >
@@ -378,7 +378,7 @@ const SubscriptionRow: FC<SubscriptionRowProps> = ({
                             superTokenAddress: subscription.token,
                             userDataBytes: undefined,
                             waitForConfirmation: false,
-                            overrides: await getTransactionOverrides(network),
+                            overrides: await getTransactionOverrides("Revoke Index Subscription", network),
                           });
                         }}
                       >

--- a/src/features/send/SendCard.tsx
+++ b/src/features/send/SendCard.tsx
@@ -506,7 +506,7 @@ export default memo(function SendCard() {
                     transactionExtraData: {
                       restoration: restoration,
                     },
-                    overrides: await getTransactionOverrides(network),
+                    overrides: await getTransactionOverrides("Create Stream", network),
                   })
                     .unwrap()
                     .then(() => resetForm());
@@ -592,7 +592,7 @@ export default memo(function SendCard() {
                       transactionExtraData: {
                         restoration: restoration,
                       },
-                      overrides: await getTransactionOverrides(network),
+                      overrides: await getTransactionOverrides("Update Stream", network),
                     })
                       .unwrap()
                       .then(() => resetForm());
@@ -646,7 +646,7 @@ export default memo(function SendCard() {
                       chainId: network.id,
                       userDataBytes: undefined,
                       waitForConfirmation: false,
-                      overrides: await getTransactionOverrides(network),
+                      overrides: await getTransactionOverrides("Close Stream", network),
                     })
                       .unwrap()
                       .then(() => resetForm());

--- a/src/features/streamsTable/CancelStreamButton/CancelStreamButton.tsx
+++ b/src/features/streamsTable/CancelStreamButton/CancelStreamButton.tsx
@@ -48,7 +48,7 @@ const CancelStreamButton: FC<CancelStreamButtonProps> = ({
       superTokenAddress: stream.token,
       userDataBytes: undefined,
       waitForConfirmation: false,
-      overrides: await getTransactionOverrides(network),
+      overrides: await getTransactionOverrides("Close Stream", network),
     }).unwrap();
   };
 

--- a/src/features/tokenWrapping/TabUnwrap.tsx
+++ b/src/features/tokenWrapping/TabUnwrap.tsx
@@ -289,7 +289,7 @@ export const TabUnwrap: FC<TabUnwrapProps> = ({
                 amountWei: parseEther(formData.amountDecimal).toString(),
               };
 
-              const overrides = await getTransactionOverrides(network);
+              const overrides = await getTransactionOverrides("Downgrade from Super Token", network);
 
               // Fix for Gnosis Safe "cannot estimate gas" issue when downgrading native asset super tokens: https://github.com/superfluid-finance/superfluid-dashboard/issues/101
               const isGnosisSafe = activeConnector?.id === "safe";

--- a/src/features/tokenWrapping/TabWrap.tsx
+++ b/src/features/tokenWrapping/TabWrap.tsx
@@ -43,10 +43,8 @@ const underlyingIbAlluoTokenOverrides = [
   "0xc677b0918a96ad258a68785c2a3955428dea7e50",
   // StIbAlluoBTC
   "0xf272ff86c86529504f0d074b210e95fc4cfcdce2",
-
   // StIbAlluoEUR
   "0xc9d8556645853c465d1d5e7d2c81a0031f0b8a92",
-
   // StIbAlluoUSD
   "0xc2dbaaea2efa47ebda3e572aa0e55b742e408bf6",
 ];
@@ -62,7 +60,6 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
   const { visibleAddress } = useVisibleAddress();
   const { setTransactionDrawerOpen } = useLayoutContext();
   const getTransactionOverrides = useGetTransactionOverrides();
-  const { connector: activeConnector } = useAccount();
 
   const {
     watch,
@@ -418,7 +415,7 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
                     transactionExtraData: {
                       restoration,
                     },
-                    overrides: await getTransactionOverrides(network),
+                    overrides: await getTransactionOverrides("Approve Allowance", network),
                   })
                     .unwrap()
                     .then(() => setTransactionDrawerOpen(true));
@@ -459,13 +456,7 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
                   amountWei: amountWei.toString(),
                 };
 
-                const overrides = await getTransactionOverrides(network);
-
-                // In Gnosis Safe, Ether's estimateGas is flaky for native assets.
-                const isGnosisSafe = activeConnector?.id === "safe";
-                const isNativeAssetSuperToken =
-                  formData.tokenPair.underlyingTokenAddress ===
-                  NATIVE_ASSET_ADDRESS;
+                const overrides = await getTransactionOverrides("Upgrade to Super Token", network);
 
                 // Temp custom override for "IbAlluo" tokens on polygon
                 // TODO: Find a better solution
@@ -476,10 +467,6 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
                   )
                 ) {
                   overrides.gasLimit = 200_000;
-                }
-
-                if (isGnosisSafe && isNativeAssetSuperToken) {
-                  overrides.gasLimit = 500_000;
                 }
 
                 setDialogLoadingInfo(

--- a/src/features/transactionBoundary/TransactionBoundary.tsx
+++ b/src/features/transactionBoundary/TransactionBoundary.tsx
@@ -1,6 +1,7 @@
 import {
   TrackedTransaction,
   TransactionInfo,
+  TransactionTitle,
   transactionTrackerSelectors,
 } from "@superfluid-finance/sdk-redux";
 import { Overrides, Signer } from "ethers";
@@ -20,7 +21,7 @@ import { useAutoConnect } from "../autoConnect/AutoConnect";
 import { useImpersonation } from "../impersonation/ImpersonationContext";
 import { useExpectedNetwork } from "../network/ExpectedNetworkContext";
 import { Network } from "../network/networks";
-import { transactionTracker, useAppSelector } from "../redux/store";
+import { useAppSelector } from "../redux/store";
 import { useConnectButton } from "../wallet/ConnectButtonProvider";
 import { TransactionDialog } from "./TransactionDialog";
 
@@ -40,7 +41,7 @@ interface TransactionBoundaryContextValue {
   setDialogLoadingInfo: (children: ReactNode) => void;
   setDialogSuccessActions: (children: ReactNode) => void;
   mutationResult: MutationResult<TransactionInfo>;
-  getOverrides: () => Promise<Overrides>;
+  getOverrides: (transactionTitle: TransactionTitle) => Promise<Overrides>;
   transaction: TrackedTransaction | undefined;
 }
 
@@ -103,7 +104,7 @@ export const TransactionBoundary: FC<TransactionBoundaryProps> = ({
       setDialogLoadingInfo,
       setDialogSuccessActions,
       mutationResult,
-      getOverrides: () => getTransactionOverrides(expectedNetwork),
+      getOverrides: (transactionTitle: TransactionTitle) => getTransactionOverrides(transactionTitle, expectedNetwork),
       transaction: trackedTransaction,
     }),
     [

--- a/src/hooks/useGetTransactionOverrides.tsx
+++ b/src/hooks/useGetTransactionOverrides.tsx
@@ -2,35 +2,83 @@ import { Overrides } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { Network } from "../features/network/networks";
 import gasApi, { GasRecommendation } from "../features/gas/gasApi.slice";
+import { useCallback } from "react";
+import { useAccount } from "wagmi";
+import { TransactionTitle } from "@superfluid-finance/sdk-redux";
 
 const useGetTransactionOverrides = () => {
   const [queryRecommendedGas] = gasApi.useLazyRecommendedGasQuery();
+  const { connector: activeConnector } = useAccount();
 
-  return async (network: Network): Promise<Overrides> => {
-    const gasQueryTimeout = new Promise<null>((response) =>
-      setTimeout(() => response(null), 3000)
-    );
-
-    const gasRecommendation = await Promise.race<GasRecommendation | null>([
-      queryRecommendedGas({ chainId: network.id }).unwrap(),
-      gasQueryTimeout,
-    ]);
-
-    const overrides: Overrides = {};
-
-    if (gasRecommendation) {
-      overrides.maxPriorityFeePerGas = parseUnits(
-        gasRecommendation.maxPriorityFeeGwei.toFixed(8).toString(),
-        "gwei"
+  return useCallback(
+    async (
+      transactionTitle: TransactionTitle,
+      network: Network
+    ): Promise<Overrides> => {
+      const gasQueryTimeout = new Promise<null>((response) =>
+        setTimeout(() => response(null), 3000)
       );
-      overrides.maxFeePerGas = parseUnits(
-        gasRecommendation.maxFeeGwei.toFixed(8).toString(),
-        "gwei"
-      );
-    }
 
-    return overrides;
-  };
+      const gasRecommendation = await Promise.race<GasRecommendation | null>([
+        queryRecommendedGas({ chainId: network.id }).unwrap(),
+        gasQueryTimeout,
+      ]);
+
+      const overrides: Overrides = {};
+
+      if (gasRecommendation) {
+        overrides.maxPriorityFeePerGas = parseUnits(
+          gasRecommendation.maxPriorityFeeGwei.toFixed(8).toString(),
+          "gwei"
+        );
+        overrides.maxFeePerGas = parseUnits(
+          gasRecommendation.maxFeeGwei.toFixed(8).toString(),
+          "gwei"
+        );
+      }
+
+      const isGnosisSafe = activeConnector?.id === "safe";
+      if (isGnosisSafe) {
+        overrides.gasLimit = tryGetHardcodedGasLimit(transactionTitle);
+      }
+
+      return overrides;
+    },
+    [queryRecommendedGas, activeConnector]
+  );
 };
 
 export default useGetTransactionOverrides;
+
+// Very approximate list of safe gas limits for operations invokable from the UI.
+const tryGetHardcodedGasLimit = (
+  transactionTitle: TransactionTitle
+): number | undefined => {
+  switch (transactionTitle) {
+    case "Create Stream":
+      return 415_000;
+    case "Update Stream":
+      return 365_000;
+    case "Close Stream":
+      return 350_000;
+    case "Revoke Index Subscription":
+      return 250_000;
+    case "Upgrade to Super Token":
+      return 160_000;
+    case "Downgrade from Super Token":
+      return 245_000;
+    case "Approve Index Subscription":
+      return 295_000;
+    case "Transfer Super Token":
+    case "Approve Allowance":
+      return undefined; // These operations are safe to use estimation for.
+    case "Create Index":
+    case "Distribute Index":
+    case "Update Index Subscription Units":
+    case "Claim from Index Subscription":
+    case "Delete Index Subscription":
+    default:
+      console.warn(`Hard-coded gas limit not defined for: ${transactionTitle}.`);
+      return undefined;
+  }
+};


### PR DESCRIPTION
Passing a hard-coded gas limits omits the gas estimation of `ethers`. We want to omit the gas estimation with Gnosis Safe because it tends to fail for Superfluid Protocol contracts. Truthfully, we could pass in any random number but I'd rather use at least somewhat realistic gas limits:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/10894666/188842175-0e26302d-6951-4db4-b3e8-0b2c2acd25e3.png">
<img width="558" alt="image" src="https://user-images.githubusercontent.com/10894666/188842836-4e478e26-c762-4482-8d88-62d4b08bfec2.png">