### PR TITLE
Disable gas estimation for Gnosis Safe

### DIFF
--- a/src/features/tokenWrapping/TabUnwrap.tsx
+++ b/src/features/tokenWrapping/TabUnwrap.tsx
@@ -291,14 +291,9 @@ export const TabUnwrap: FC<TabUnwrapProps> = ({
 
               const overrides = await getTransactionOverrides(network);
 
-              // Fix for Gnosis Safe "cannot estimate gas" issue when downgrading native asset super tokens: https://github.com/superfluid-finance/superfluid-dashboard/issues/101
-              const isGnosisSafe = activeConnector?.id === "safe";
               const isNativeAssetSuperToken =
                 formData.tokenPair.underlyingTokenAddress ===
                 NATIVE_ASSET_ADDRESS;
-              if (isGnosisSafe && isNativeAssetSuperToken) {
-                overrides.gasLimit = 500_000;
-              }
 
               setDialogLoadingInfo(
                 <UnwrapPreview

--- a/src/features/tokenWrapping/TabWrap.tsx
+++ b/src/features/tokenWrapping/TabWrap.tsx
@@ -461,12 +461,6 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
 
                 const overrides = await getTransactionOverrides(network);
 
-                // In Gnosis Safe, Ether's estimateGas is flaky for native assets.
-                const isGnosisSafe = activeConnector?.id === "safe";
-                const isNativeAssetSuperToken =
-                  formData.tokenPair.underlyingTokenAddress ===
-                  NATIVE_ASSET_ADDRESS;
-
                 // Temp custom override for "IbAlluo" tokens on polygon
                 // TODO: Find a better solution
                 if (
@@ -476,10 +470,6 @@ export const TabWrap: FC<TabWrapProps> = ({ onSwitchMode }) => {
                   )
                 ) {
                   overrides.gasLimit = 200_000;
-                }
-
-                if (isGnosisSafe && isNativeAssetSuperToken) {
-                  overrides.gasLimit = 500_000;
                 }
 
                 setDialogLoadingInfo(

--- a/src/hooks/useGetTransactionOverrides.tsx
+++ b/src/hooks/useGetTransactionOverrides.tsx
@@ -2,35 +2,46 @@ import { Overrides } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { Network } from "../features/network/networks";
 import gasApi, { GasRecommendation } from "../features/gas/gasApi.slice";
+import { useCallback } from "react";
+import { useAccount } from "wagmi";
 
 const useGetTransactionOverrides = () => {
   const [queryRecommendedGas] = gasApi.useLazyRecommendedGasQuery();
+  const { connector: activeConnector } = useAccount();
 
-  return async (network: Network): Promise<Overrides> => {
-    const gasQueryTimeout = new Promise<null>((response) =>
-      setTimeout(() => response(null), 3000)
-    );
-
-    const gasRecommendation = await Promise.race<GasRecommendation | null>([
-      queryRecommendedGas({ chainId: network.id }).unwrap(),
-      gasQueryTimeout,
-    ]);
-
-    const overrides: Overrides = {};
-
-    if (gasRecommendation) {
-      overrides.maxPriorityFeePerGas = parseUnits(
-        gasRecommendation.maxPriorityFeeGwei.toFixed(8).toString(),
-        "gwei"
+  return useCallback(
+    async (network: Network): Promise<Overrides> => {
+      const gasQueryTimeout = new Promise<null>((response) =>
+        setTimeout(() => response(null), 3000)
       );
-      overrides.maxFeePerGas = parseUnits(
-        gasRecommendation.maxFeeGwei.toFixed(8).toString(),
-        "gwei"
-      );
-    }
 
-    return overrides;
-  };
+      const gasRecommendation = await Promise.race<GasRecommendation | null>([
+        queryRecommendedGas({ chainId: network.id }).unwrap(),
+        gasQueryTimeout,
+      ]);
+
+      const overrides: Overrides = {};
+
+      if (gasRecommendation) {
+        overrides.maxPriorityFeePerGas = parseUnits(
+          gasRecommendation.maxPriorityFeeGwei.toFixed(8).toString(),
+          "gwei"
+        );
+        overrides.maxFeePerGas = parseUnits(
+          gasRecommendation.maxFeeGwei.toFixed(8).toString(),
+          "gwei"
+        );
+      }
+
+      const isGnosisSafe = activeConnector?.id === "safe";
+      if (isGnosisSafe) {
+        overrides.gasLimit = 0; // Disable gas estimation for Gnosis Safe completely because they don't use it anyway.
+      }
+
+      return overrides;
+    },
+    [queryRecommendedGas, activeConnector]
+  );
 };
 
 export default useGetTransactionOverrides;


### PR DESCRIPTION
Simpler version: for Gnosis Safe, set `gasLimit` to 0 always.