### PR TITLE
Hide production source maps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,6 +51,10 @@ const moduleExports = {
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: SENTRY_ENVIRONMENT,
   },
   swcMinify: true, // Recommended by next-transpile-modules
+  productionBrowserSourceMaps: false, // Sentry will override this to `true`...
+  sentry: {
+    hideSourceMaps: true // If this not specified then Sentry will expose the production source maps. 
+  }
 };
 
 module.exports = withTM(withSentryIfNecessary(moduleExports));


### PR DESCRIPTION
Apparently Sentry overrides the Next.js's default `productionBrowserSourceMaps=false` to `true` and exposes the production source maps. To remove this behaviour then a separate `hideSourceMaps=true` has to be passed to Sentry...