### PR TITLE
Fix burning issue of not being able to send or modify streams

### DIFF
--- a/src/eth-sdk/getEthSdk.ts
+++ b/src/eth-sdk/getEthSdk.ts
@@ -10,5 +10,5 @@ export const getEthSdk = (
         return getGoerliSdk(providerOrSigner);
     }
 
-    throw new Error();
+    throw new Error("Eth-SDK not available for network.");
 };

--- a/src/features/redux/endpoints/streamSchedulerEndpoints.ts
+++ b/src/features/redux/endpoints/streamSchedulerEndpoints.ts
@@ -84,7 +84,6 @@ export const streamSchedulerEndpoints = {
           ).unwrap(),
         ]);
 
-        const { streamScheduler } = getEthSdk(chainId, arg.signer);
         const subOperations: {
           operation: Operation;
           title: TransactionTitle;
@@ -92,6 +91,8 @@ export const streamSchedulerEndpoints = {
 
         const network = findNetworkByChainId(chainId);
         if (network?.streamSchedulerContractAddress) {
+          const { streamScheduler } = getEthSdk(chainId, arg.signer);
+
           const existingEndTimestamp = await dispatch(
             rpcApi.endpoints.scheduledEndDate.initiate(
               {


### PR DESCRIPTION
My bad, sorry. Simple mistake but grave repercussions. Note to self: don't ever throw errors without a message.

In general, Dashboard V2 is been live for a while now and it's becoming more of an expectation for it to always function properly. Will think of a process to make it more stable.

Some thoughts:
- Keep on cleaning up the errors logs, still very messy. Also share the knowledge of debugging errors from Sentry.
- Finish analytics, can help with debugging.
- Unit tests for the critical paths. We've only relied on end-to-end tests but the critical paths deserve unit tests as well.
- Slow down the production deployments a bit. Currently deploy off of `master` is published automatically. 
  - It's good that `master` branch is built and deployed but the actual publishing can be done manually after a more extensive special test-suite runs on the _to-be_ production deploy. We don't want this extensive test-suite running on deploy-previews though because that starts to slow down development.
  - Sometimes something is ready to be merged into `master` but not necessarily a new publishing is needed yet.
  - Having the experience of pressing the publish button reduces the fear of doing a rollback (which is super easy to do actually). 
- Have #bug-reports from Discord forward to Slack too?
- Discussing with @elvijsTDL to have tests that invoke the wallet for the transaction but not actually broadcast it. This way we can quickly and cheaply end-to-end test the most important logic of transactions on all the networks.