### PR TITLE
Fine-tune Segment's Identify call

### DIFF
--- a/src/components/MonitorContext/MonitorContext.tsx
+++ b/src/components/MonitorContext/MonitorContext.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import { useRouter } from "next/router";
 import promiseRetry from "promise-retry";
-import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { hotjar } from "react-hotjar";
 import { useIntercom } from "react-use-intercom";
 import {

--- a/src/features/analytics/useAnalytics.tsx
+++ b/src/features/analytics/useAnalytics.tsx
@@ -4,7 +4,7 @@ import { serialize } from "wagmi";
 import * as Sentry from "@sentry/react";
 import { AnalyticsContext } from "./AnalyticsProvider";
 import { AnalyticsTransactionNames } from "./AnalyticsTxNames";
-import { AppInstanceDetails, WalletDetails } from "./useAppInstanceDetails";
+import { ConnectedWalletDetails } from "./useAppInstanceDetails";
 
 export const useAnalytics = () => {
   const { analyticsBrowser, instanceDetails } = useContext(AnalyticsContext);
@@ -55,7 +55,7 @@ export const useAnalytics = () => {
   );
 
   const identify = useCallback(
-    (wallet: WalletDetails) =>
+    (wallet: ConnectedWalletDetails) =>
       analyticsBrowser.identify(wallet.address, {
         walletAddress: wallet.address,
       }),

--- a/src/features/analytics/useAppInstanceDetails.tsx
+++ b/src/features/analytics/useAppInstanceDetails.tsx
@@ -18,18 +18,26 @@ export type AppInstanceDetails = {
       slug: string;
       isTestnet: boolean;
     };
-    wallet: {
-      isConnected: boolean;
-      address?: string;
-      connector?: string;
-      connectorId?: string;
-      network?: string;
-      networkId?: number;
-    };
+    wallet: UnconnectedWalletDetails | ConnectedWalletDetails;
   };
 };
 
-export type WalletDetails = AppInstanceDetails["appInstance"]["wallet"];
+export type UnconnectedWalletDetails = {
+  isConnected: false;
+  address?: undefined;
+  connector?: undefined;
+  connectorId?: undefined;
+  network?: undefined;
+  networkId?: undefined;
+};
+export type ConnectedWalletDetails = {
+  isConnected: boolean;
+  address: string;
+  connector: string;
+  connectorId: string;
+  network?: string;
+  networkId?: number;
+};
 
 export const useAppInstanceDetails = () => {
   const { chain: activeChain } = useNetwork();
@@ -52,8 +60,8 @@ export const useAppInstanceDetails = () => {
     transactionDrawerOpen,
   ];
 
-  return useMemo<AppInstanceDetails>(
-    () => ({
+  return useMemo<AppInstanceDetails>(() => {
+    return {
       appInstance: {
         supportId: supportId,
         expectedNetwork: {
@@ -62,10 +70,10 @@ export const useAppInstanceDetails = () => {
           slug: expectedNetwork.slugName,
           isTestnet: !!expectedNetwork.testnet,
         },
-        wallet: {
-          isConnected,
-          ...(isConnected && activeConnector
+        wallet:
+          isConnected && activeConnector && activeAccountAddress
             ? {
+                isConnected: true,
                 isReconnected: isAutoConnectedRef.current,
                 address: activeAccountAddress,
                 connector: activeConnector.name,
@@ -77,10 +85,8 @@ export const useAppInstanceDetails = () => {
                     }
                   : {}),
               }
-            : {}),
-        },
+            : { isConnected: false },
       },
-    }),
-    deps
-  );
+    };
+  }, deps);
 };


### PR DESCRIPTION
Trying to figure out why this page is empty even though there are many `identify` calls as observed from the Debugger:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/10894666/218085668-e3fe7b4a-19d0-48c3-abb7-318649d25eb9.png">
<img width="892" alt="image" src="https://user-images.githubusercontent.com/10894666/218085882-234b285a-5ea3-444b-8c6e-767fcd695d10.png">