### PR TITLE
[Small bug fix] Fix duplicate pending delete state appearing for vesting

### DIFF
--- a/src/features/pendingUpdates/PendingVestingScheduleDelete.ts
+++ b/src/features/pendingUpdates/PendingVestingScheduleDelete.ts
@@ -38,28 +38,35 @@ export const useAddressPendingVestingScheduleDeletes = (
   );
 };
 
-export const usePendingVestingScheduleDelete = ({
-  chainId,
-  superTokenAddress,
-  senderAddress,
-  receiverAddress,
-}: {
-  chainId: number;
-  superTokenAddress: string;
-  senderAddress: string;
-  receiverAddress: string;
-}) => {
+export const usePendingVestingScheduleDelete = (
+  {
+    chainId,
+    superTokenAddress,
+    senderAddress,
+    receiverAddress,
+  }: {
+    chainId: number;
+    superTokenAddress: string;
+    senderAddress: string;
+    receiverAddress: string;
+  },
+  options?: { skip: boolean }
+) => {
   const list = useAddressPendingVestingScheduleDeletes(senderAddress);
+
+  const skip = options?.skip ?? false;
 
   return useMemo(
     () =>
-      list.filter(
-        (x) =>
-          x.chainId === chainId &&
-          x.superTokenAddress.toLowerCase() ===
-            superTokenAddress.toLowerCase() &&
-          x.receiverAddress.toLowerCase() === receiverAddress.toLowerCase()
-      )[0], // We assume no duplicates here.
-    [chainId, superTokenAddress, receiverAddress, list]
+      skip
+        ? undefined
+        : list.filter(
+            (x) =>
+              x.chainId === chainId &&
+              x.superTokenAddress.toLowerCase() ===
+                superTokenAddress.toLowerCase() &&
+              x.receiverAddress.toLowerCase() === receiverAddress.toLowerCase()
+          )[0], // We assume no duplicates here.
+    [chainId, superTokenAddress, receiverAddress, list, skip]
   );
 };

--- a/src/features/vesting/VestingRow.tsx
+++ b/src/features/vesting/VestingRow.tsx
@@ -47,12 +47,17 @@ const VestingRow: FC<VestingRowProps> = ({
     cliffAndFlowDate,
   } = vestingSchedule;
 
-  const pendingDelete = usePendingVestingScheduleDelete({
-    chainId: network.id,
-    superTokenAddress: superToken,
-    receiverAddress: receiver,
-    senderAddress: sender,
-  });
+  const pendingDelete = usePendingVestingScheduleDelete(
+    {
+      chainId: network.id,
+      superTokenAddress: superToken,
+      receiverAddress: receiver,
+      senderAddress: sender,
+    },
+    {
+      skip: vestingSchedule.status.isFinished,
+    }
+  );
 
   const { visibleAddress } = useVisibleAddress();
 


### PR DESCRIPTION
Why?
UI falsely showed "Deleting..." for already finished vesting schedule when another vesting schedule with the same token-sender-receiver was being deleted:
![image](https://user-images.githubusercontent.com/10894666/223654146-df44948f-ad60-41e2-a603-9a60773496d8.png)