### PR TITLE
fix: update polygon gas station urls

### DIFF
--- a/src/features/gas/gasApi.slice.ts
+++ b/src/features/gas/gasApi.slice.ts
@@ -24,8 +24,8 @@ const gasApi = createApi({
           );
           return {
             data: {
-              maxFeeGwei: maxFee,
-              maxPriorityFeeGwei: maxPriorityFee,
+              maxFeeGwei: Number(maxFee),
+              maxPriorityFeeGwei: Number(maxPriorityFee),
             } as GasRecommendation,
           };
         }
@@ -41,8 +41,8 @@ const gasApi = createApi({
           );
           return {
             data: {
-              maxFeeGwei: maxFee,
-              maxPriorityFeeGwei: maxPriorityFee,
+              maxFeeGwei: Number(maxFee),
+              maxPriorityFeeGwei: Number(maxPriorityFee),
             } as GasRecommendation,
           };
         }


### PR DESCRIPTION
Polygon fumbled something up and urgently migrating the Gas Station endpoints. The new endpoints are from the official docs: https://wiki.polygon.technology/docs/develop/tools/polygon-gas-station/

There could still be some issues as the endpoints are weirdly intermingling strings and numbers:
![image](https://github.com/superfluid-finance/superfluid-dashboard/assets/10894666/b08da4ab-c03e-495a-abf8-4145dcc448c6)