### PR TITLE
fix: get featured tokens for Li.Fi only for mainnets

### DIFF
--- a/src/features/bridge/useFeaturedTokens.tsx
+++ b/src/features/bridge/useFeaturedTokens.tsx
@@ -4,7 +4,7 @@ import { useAvailableNetworks } from "../network/AvailableNetworksContext";
 import { subgraphApi } from "../redux/store";
 
 const useFeaturedTokens = (lifi: LiFi): Token[] => {
-  const { availableNetworks } = useAvailableNetworks();
+  const { availableMainNetworks } = useAvailableNetworks();
   const [featuredTokens, setFeaturedTokens] = useState<Token[]>([]);
 
   const [tokenQueryTrigger] = subgraphApi.useLazyTokensQuery();
@@ -12,7 +12,7 @@ const useFeaturedTokens = (lifi: LiFi): Token[] => {
   useEffect(() => {
     if (!lifi) return;
     setFeaturedTokens([]);
-    const availableChainIds = availableNetworks.map((x) => x.id);
+    const availableChainIds = availableMainNetworks.map((x) => x.id); // Note that if the chain ID is not supported by Li.Fi then the request will return 400 (Bad Request).
 
     lifi.getTokens({ chains: availableChainIds }).then((lifiTokensResponse) => {
       Promise.all(
@@ -57,7 +57,7 @@ const useFeaturedTokens = (lifi: LiFi): Token[] => {
         );
       });
     });
-  }, [lifi, tokenQueryTrigger, availableNetworks]);
+  }, [lifi, tokenQueryTrigger, availableMainNetworks]);
 
   return featuredTokens;
 };


### PR DESCRIPTION
Noticed this on the bridge page, fixed it quickly.

![image](https://github.com/superfluid-finance/superfluid-dashboard/assets/10894666/7317f069-203f-4745-879a-871361988d49)
![image](https://github.com/superfluid-finance/superfluid-dashboard/assets/10894666/99cd148a-b84a-4fa5-94cf-5bdd687ba941)