### PR TITLE
Feature: allow coinshift in SafeWallet

### DIFF
--- a/src/features/wallet/gnosisSafeWalletConnector/gnosisSafe.ts
+++ b/src/features/wallet/gnosisSafeWalletConnector/gnosisSafe.ts
@@ -20,6 +20,7 @@ const gnosisSafe = ({ chains }: GnosisSafeOptions): Wallet => {
             /gnosis-safe.io$/,
             /app.safe.global$/,
             /^https:\/\/(?:[^\/]+\.)?coinshift\.xyz$/,
+            /^http:\/\/(localhost|127\.0\.0\.1):(\d+)$/,
           ],
           debug: false,
         },


### PR DESCRIPTION
- allow coinshift and its subdomains in safe wallet 
- allow localhost

#### Matching examples (`/^https:\/\/(?:[^\/]+\.)?coinshift\.xyz$/`):
- `https://coinshift.xyz`
- `https://www.coinshift.xyz`
- `https://sub.coinshift.xyz`
#### Non-matching examples:
- `http://coinshift.xyz`
- ` https://coinshift.xyz/path`
- ` https://coinshift.com`
---------------------------------------------------------------------
#### Matching examples (`/^http:\/\/(localhost|127\.0\.0\.1):(\d+)$/`):
- `http://localhost:80`
- `http://localhost:8080`
- `http://127.0.0.1:3000`
#### Non-matching examples
- `https://localhost:80`
- `http://localhost`
- `http://127.0.0.1`
