### PR TITLE
fix: stop vested balance when vesting schedule deleted

### DIFF
--- a/src/utils/vestingUtils.ts
+++ b/src/utils/vestingUtils.ts
@@ -224,8 +224,8 @@ export function vestingScheduleToTokenBalance(
   if (failedAt) return null;
 
   const effectiveEndAt = endExecutedAt || deletedAt;
-  if (effectiveEndAt) {
-    const secondsStreamed = Number(Math.max(effectiveEndAt)) - cliffAndFlowDate;
+  if (effectiveEndAt && effectiveEndAt > cliffAndFlowDate) {
+    const secondsStreamed = effectiveEndAt - cliffAndFlowDate;
     const balance = BigNumber.from(secondsStreamed)
       .mul(flowRate)
       .add(cliffAmount)


### PR DESCRIPTION
Why? The vested balance kept flowing even when the schedule had been deleted.

https://superfluidhq.slack.com/archives/C02K8UDDLR0/p1705330559171429