### PR TITLE
add custom tokens through the window object

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,8 @@ This repository implements the Superfluid Dashboard v2 as a Next.js web app buil
 
 ### `window.superfluid_dashboard.advanced.nextGasOverrides`
 
-`ethers` `Overrides` to override gas settings for only the next transaction attempt.
+`ethers` `Overrides` to override gas settings for only the next transaction attempt. Example usage: `window.superfluid_dashboard.advanced.nextGasOverrides.gasLimit = 1_000_000`
+
+### `window.superfluid_dashboard.advanced.addCustomToken`
+
+`addCustomToken` is a function that allows you to add a custom token to the Superfluid Dashboard. Example usage: `window.superfluid_dashboard.advanced.addCustomToken({ chainId: 1, customToken: "0xd27dd3deec7eb1f1f48d9eb66f4a548c8cc04889" })`

--- a/src/features/redux/store.ts
+++ b/src/features/redux/store.ts
@@ -323,5 +323,5 @@ export type AppStore = typeof reduxStore;
 export type RootState = ReturnType<AppStore["getState"]>;
 export type AppDispatch = AppStore["dispatch"];
 
-export const useAppDispatch = () => useDispatch<Dispatch>();
+export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,12 +1,19 @@
 import { isUndefined } from "lodash";
 import { GlobalGasOverrides } from "./typings/global";
 import { SSR } from "./utils/SSRUtils";
+import { AppDispatch } from "./features/redux/store";
+import { addCustomToken, NetworkCustomToken } from "./features/customTokens/customTokens.slice";
 
-export const initializeSuperfluidDashboardGlobalObject = () => {
+export const initializeSuperfluidDashboardGlobalObject = ({
+  appDispatch
+}: { appDispatch: AppDispatch }) => {
   if (!SSR && !window.superfluid_dashboard) {
     window.superfluid_dashboard = {
       advanced: {
         nextGasOverrides: createEmptyGasOverrides(),
+        addCustomToken: async (token: NetworkCustomToken) => {
+          await appDispatch(addCustomToken(token));
+        },
       },
     };
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,11 +27,11 @@ import WagmiManager from "../features/wallet/WagmiManager";
 import { initializeSuperfluidDashboardGlobalObject } from "../global";
 import { IsCypress } from "../utils/SSRUtils";
 import config from "../utils/config";
+import { useStore } from "react-redux";
+import { useAppDispatch } from "../features/redux/store";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
-
-initializeSuperfluidDashboardGlobalObject();
 
 export interface MyAppProps extends AppProps {
   emotionCache?: EmotionCache;
@@ -101,9 +101,22 @@ export default function MyApp(props: AppPropsWithLayout) {
                 </ExpectedNetworkProvider>
               </ImpersonationProvider>
             </AvailableNetworksProvider>
+            <GlobalSuperfluidDashboardObjectInitializer />
           </ReduxProvider>
         </WagmiManager>
       </CacheProvider>
     </NextThemesProvider>
   );
+}
+
+function GlobalSuperfluidDashboardObjectInitializer() {
+  const appDispatch = useAppDispatch();
+
+  useEffect(() => {
+    initializeSuperfluidDashboardGlobalObject({
+      appDispatch,
+    });
+  }, [appDispatch]);
+
+  return null;
 }

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -10,6 +10,7 @@ export type SuperfluidDashboardGlobal = {
   advanced: {
     // Will be used to override gas settings for the next transaction attempt.
     nextGasOverrides: GlobalGasOverrides;
+    addCustomToken: (token: NetworkCustomToken) => Promise<void>;
   };
 };
 


### PR DESCRIPTION
For Fran's demo. Useful anyway.

```
### `window.superfluid_dashboard.advanced.addCustomToken`

`addCustomToken` is a function that allows you to add a custom token to the Superfluid Dashboard. Example usage: `window.superfluid_dashboard.advanced.addCustomToken({ chainId: 1, customToken: "0xd27dd3deec7eb1f1f48d9eb66f4a548c8cc04889" })`
```