### PR TITLE
Add EFP data to Address Book

### DIFF
--- a/src/components/AddressName/AddressName.tsx
+++ b/src/components/AddressName/AddressName.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { ens_beautify } from "@adraffy/ens-normalize";
 import useAddressName from "../../hooks/useAddressName";
 import shortenHex from "../../utils/shortenHex";
 
@@ -14,16 +15,16 @@ export default memo(function AddressName({
   const addressName = useAddressName(address);
 
   if (addressName.name) {
-    return <>{addressName.name}</>;
+    return <>{ens_beautify(addressName.name)}</>;
   } else {
     return (
       <>
         {length === "long"
           ? addressName.addressChecksummed
           : shortenHex(
-              addressName.addressChecksummed,
-              length === "medium" ? 8 : 4
-            )}
+            addressName.addressChecksummed,
+            length === "medium" ? 8 : 4
+          )}
       </>
     );
   }

--- a/src/features/addressBook/AddressBookLoadingRow.tsx
+++ b/src/features/addressBook/AddressBookLoadingRow.tsx
@@ -1,0 +1,47 @@
+import {
+  Box,
+  Skeleton,
+  Stack,
+  TableCell,
+  TableRow,
+} from "@mui/material";
+
+const AddressBookLoadingRow = () => {
+  return (
+    <TableRow>
+      <TableCell>
+        <Stack direction="row" alignItems="center" gap={2}>
+          <Skeleton variant="rectangular" width="34px" height="27px" sx={{ borderRadius: "30%" }} />
+          <Skeleton variant="text" width="100%" height="26px" />
+        </Stack>
+      </TableCell>
+
+      <TableCell data-cy={"actual-address"}>
+        <Stack direction="column">
+          <Skeleton variant="text" width="100%" height="28px" />
+        </Stack>
+      </TableCell>
+
+      <TableCell>
+        <Box
+          data-cy="networks"
+          sx={{ overflow: "auto", scrollbarWidth: "none" }}
+        >
+          <Skeleton variant="rounded" width="24px" height="24px" sx={{ transform: `translateX(${0}px) translateY(${24}px)` }} />
+          <Skeleton variant="rounded" width="24px" height="24px" sx={{ transform: `translateX(${16}px) translateY(${0}px)` }} />
+          <Skeleton variant="rounded" width="24px" height="24px" sx={{ transform: `translateX(${32}px) translateY(${-24}px)` }} />
+        </Box>
+      </TableCell>
+
+      <TableCell data-cy={"active-streams"}>
+        <Skeleton width="30px" />
+      </TableCell>
+
+      <TableCell data-cy={"active-streams"}>
+        {/* <Skeleton width="30px" /> */}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default AddressBookLoadingRow;

--- a/src/features/addressBook/AddressBookMobileLoadingRow.tsx
+++ b/src/features/addressBook/AddressBookMobileLoadingRow.tsx
@@ -1,0 +1,26 @@
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox";
+import {
+  Checkbox,
+  Skeleton,
+  Stack,
+  TableCell,
+  TableRow,
+} from "@mui/material";
+
+const AddressBookMobileLoadingRow = () => {
+  return (
+    <TableRow>
+      <TableCell>
+        <Stack direction="row" alignItems="center" gap={1.5}>
+          <Skeleton variant="rectangular" width="34px" height="27px" sx={{ borderRadius: "30%" }} />
+          <Skeleton variant="text" width="100%" height="26px" />
+        </Stack>
+      </TableCell>
+      <TableCell width="64px">
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default AddressBookMobileLoadingRow;

--- a/src/features/addressBook/AddressBookMobileRow.tsx
+++ b/src/features/addressBook/AddressBookMobileRow.tsx
@@ -16,12 +16,15 @@ import AddressAvatar from "../../components/Avatar/AddressAvatar";
 import AddressName from "../../components/AddressName/AddressName";
 import useAddressName from "../../hooks/useAddressName";
 import shortenHex from "../../utils/shortenHex";
+import { Star, StarBorder } from "@mui/icons-material";
 
 interface AddressBookMobileRowProps {
   address: Address;
   selectable: boolean;
   selected: boolean;
   onSelect: (isSelected: boolean) => void;
+  isStarred?: boolean;
+  onStarClick?: () => void;
 }
 
 const AddressBookMobileRow: FC<AddressBookMobileRowProps> = ({
@@ -29,6 +32,8 @@ const AddressBookMobileRow: FC<AddressBookMobileRowProps> = ({
   selectable,
   selected,
   onSelect,
+  isStarred = false,
+  onStarClick,
 }) => {
   const { name } = useAddressName(address);
 
@@ -54,6 +59,11 @@ const AddressBookMobileRow: FC<AddressBookMobileRowProps> = ({
         </Stack>
       </TableCell>
       <TableCell width="64px">
+        {onStarClick &&
+          (isStarred ?
+            <Star color="primary" sx={{ width: 26, height: 26 }} onClick={onStarClick} />
+            : <StarBorder color="primary" sx={{ width: 26, height: 26 }} onClick={onStarClick} />
+          )}
         {selectable && (
           <Checkbox
             checked={selected}

--- a/src/features/addressBook/AddressBookRow.tsx
+++ b/src/features/addressBook/AddressBookRow.tsx
@@ -38,6 +38,7 @@ import { allNetworks, tryFindNetwork } from "../network/networks";
 import NetworkIcon from "../network/NetworkIcon";
 import { useVisibleAddress } from "../wallet/VisibleAddressContext";
 import { CopyIconBtn } from "../common/CopyIconBtn";
+import { Star, StarBorder } from "@mui/icons-material";
 
 interface AddressBookRowProps {
   address: Address;
@@ -50,6 +51,8 @@ interface AddressBookRowProps {
   isContract?: boolean;
   onSelect: (isSelected: boolean) => void;
   canEdit?: boolean;
+  isStarred?: boolean;
+  onStarClick?: () => void;
 }
 
 const WideTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -71,6 +74,8 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
   isContract = false,
   onSelect,
   canEdit = true,
+  isStarred = false,
+  onStarClick,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -79,6 +84,7 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
   const [editableName, setEditableName] = useState(name);
   const [isEditing, setIsEditing] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
+  const [isHoveringStar, setIsHoveringStar] = useState(false);
   const { ensName, lensName } = useAddressName(address);
 
   const trimmedName = useMemo(() => editableName.trim(), [editableName]);
@@ -121,9 +127,17 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
   );
 
   return (
-    <TableRow onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <TableCell>
-        <Stack direction="row">
+    <TableRow onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} >
+      <TableCell sx={{ pl: onStarClick ? 1 : 4 }}>
+        <Stack direction="row" alignItems="center" gap={1}>
+          {onStarClick &&
+            <Stack alignItems="center" justifyContent="center" onMouseEnter={() => setIsHoveringStar(true)} onMouseLeave={() => setIsHoveringStar(false)} onClick={onStarClick} sx={{ cursor: 'pointer', opacity: isHovering || isStarred ? 1 : 0 }}>
+              {isHoveringStar || isStarred ?
+                <Star color="primary" sx={{ width: 20, height: 20, cursor: 'pointer' }} />
+                : <StarBorder color="primary" sx={{ width: 20, height: 20 }} />
+              }
+            </Stack>
+          }
           <Stack direction="row" alignItems="center" gap={1.5}>
             <AddressAvatar
               address={address}

--- a/src/features/addressBook/AddressBookRow.tsx
+++ b/src/features/addressBook/AddressBookRow.tsx
@@ -48,6 +48,7 @@ interface AddressBookRowProps {
   chainIds?: number[];
   isContract?: boolean;
   onSelect: (isSelected: boolean) => void;
+  canEdit?: boolean;
 }
 
 const WideTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -68,6 +69,7 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
   chainIds,
   isContract = false,
   onSelect,
+  canEdit = true,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -92,7 +94,7 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
     setIsEditing(false);
   }, [trimmedName, address, dispatch]);
 
-  const startEditing = () => setIsEditing(true);
+  const startEditing = () => canEdit && setIsEditing(true);
 
   const cancelEditing = useCallback(() => {
     setIsEditing(false);
@@ -149,7 +151,7 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
               </Typography>
             )}
 
-            {(isEditing || isHovering) && (
+            {canEdit && (isEditing || isHovering) && (
               <>
                 <Tooltip
                   placement="top"

--- a/src/features/addressBook/AddressBookRow.tsx
+++ b/src/features/addressBook/AddressBookRow.tsx
@@ -27,6 +27,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { ens_beautify } from "@adraffy/ens-normalize";
 import AddressAvatar from "../../components/Avatar/AddressAvatar";
 import AddressName from "../../components/AddressName/AddressName";
 import useAddressName from "../../hooks/useAddressName";
@@ -214,7 +215,7 @@ const AddressBookRow: FC<AddressBookRowProps> = ({
               variant="tooltip"
               sx={{ fontSize: 12 }}
             >
-              {ensName}
+              {ens_beautify(ensName)}
             </Typography>
           )}
 

--- a/src/features/efp/efpApi.slice.ts
+++ b/src/features/efp/efpApi.slice.ts
@@ -5,6 +5,7 @@ export interface getFollowingParams {
 	address?: string
 	offset: number
 	limit: number
+	search?: string
 }
 
 export interface getFollowingResponse {
@@ -28,13 +29,17 @@ export const efpApi = createApi({
 				getFollowingResponse[],
 				getFollowingParams
 			>({
-				queryFn: async ({ address, offset, limit }) => {
+				queryFn: async ({ address, offset, limit, search }) => {
 					if (!address) {
 						return { data: [] }
 					}
 
 					const following = await fetch(
-						`${EFP_API_URL}/users/${address}/following?offset=${offset}&limit=${limit}&sort=followers`
+						`${EFP_API_URL}/users/${address}/${
+							search ? 'searchFollowing' : 'following'
+						}?offset=${offset}&limit=${limit}&sort=followers${
+							search ? `&term=${search}` : ''
+						}`
 					)
 					const data = await following.json()
 					return { data: data.following }

--- a/src/features/efp/efpApi.slice.ts
+++ b/src/features/efp/efpApi.slice.ts
@@ -34,7 +34,7 @@ export const efpApi = createApi({
 					}
 
 					const following = await fetch(
-						`${EFP_API_URL}/users/${address}/following?offset=${offset}&limit=${limit}`
+						`${EFP_API_URL}/users/${address}/following?offset=${offset}&limit=${limit}&sort=followers`
 					)
 					const data = await following.json()
 					return { data: data.following }

--- a/src/features/efp/efpApi.slice.ts
+++ b/src/features/efp/efpApi.slice.ts
@@ -1,0 +1,64 @@
+import { fakeBaseQuery } from '@reduxjs/toolkit/dist/query'
+import { createApi } from '@reduxjs/toolkit/dist/query/react'
+
+export interface getFollowingParams {
+	address?: string
+	offset: number
+	limit: number
+}
+
+export interface getFollowingResponse {
+	address: string
+}
+
+export interface getStatsResponse {
+	following: number
+	followers: number
+}
+
+export const efpApi = createApi({
+	reducerPath: 'efp',
+	baseQuery: fakeBaseQuery(),
+	keepUnusedDataFor: 500,
+	endpoints: builder => {
+		const EFP_API_URL = 'https://data.ethfollow.xyz/api/v1'
+
+		return {
+			getFollowing: builder.query<
+				getFollowingResponse[],
+				getFollowingParams
+			>({
+				queryFn: async ({ address, offset, limit }) => {
+					if (!address) {
+						return { data: [] }
+					}
+
+					const following = await fetch(
+						`${EFP_API_URL}/users/${address}/following?offset=${offset}&limit=${limit}`
+					)
+					const data = await following.json()
+					return { data: data.following }
+				},
+			}),
+			getStats: builder.query<getStatsResponse, string | undefined>({
+				queryFn: async address => {
+					if (!address) {
+						return { data: { following: 0, followers: 0 } }
+					}
+
+					const response = await fetch(
+						`${EFP_API_URL}/users/${address}/stats`
+					)
+					const data = await response.json()
+
+					const stats = {
+						following: data.following_count,
+						followers: data.followers_count,
+					}
+
+					return { data: stats }
+				},
+			}),
+		}
+	},
+})

--- a/src/features/redux/store.ts
+++ b/src/features/redux/store.ts
@@ -1,381 +1,324 @@
 import {
-	autoBatchEnhancer,
-	configureStore,
-	createListenerMiddleware,
-	EntityState,
-	isRejected,
-	isRejectedWithValue,
-	Middleware,
-	MiddlewareAPI,
-} from '@reduxjs/toolkit'
-import { setupListeners } from '@reduxjs/toolkit/query'
-import * as Sentry from '@sentry/react'
+  autoBatchEnhancer,
+  configureStore,
+  createListenerMiddleware,
+  EntityState,
+  isRejected,
+  isRejectedWithValue,
+  Middleware,
+  MiddlewareAPI,
+} from "@reduxjs/toolkit";
 import {
-	allRpcEndpoints,
-	allSubgraphEndpoints,
-	createApiWithReactHooks,
-	initializeRpcApiSlice,
-	initializeSubgraphApiSlice,
-	initializeTransactionTrackerSlice,
-	TrackedTransaction,
-} from '@superfluid-finance/sdk-redux'
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+  setupListeners,
+} from "@reduxjs/toolkit/query";
+import * as Sentry from "@sentry/react";
 import {
-	FLUSH,
-	PAUSE,
-	PERSIST,
-	PersistedState,
-	persistReducer,
-	persistStore,
-	PURGE,
-	REGISTER,
-	REHYDRATE,
-} from 'redux-persist'
-import storage from 'redux-persist/lib/storage'
-import { deserializeError } from 'serialize-error'
-import { schedulingSubgraphApi } from '../../scheduling-subgraph/schedulingSubgraphApi'
-import { vestingSubgraphApi } from '../../vesting-subgraph/vestingSubgraphApi'
-import accountingApi from '../accounting/accountingApi.slice'
+  allRpcEndpoints,
+  allSubgraphEndpoints,
+  createApiWithReactHooks,
+  initializeRpcApiSlice,
+  initializeSubgraphApiSlice,
+  initializeTransactionTrackerSlice,
+  TrackedTransaction,
+} from "@superfluid-finance/sdk-redux";
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import {
-	addressBookSlice,
-	AddressBookState,
-} from '../addressBook/addressBook.slice'
+  FLUSH,
+  PAUSE,
+  PERSIST,
+  PersistedState,
+  persistReducer,
+  persistStore,
+  PURGE,
+  REGISTER,
+  REHYDRATE,
+} from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import { deserializeError } from "serialize-error";
+import { schedulingSubgraphApi } from "../../scheduling-subgraph/schedulingSubgraphApi";
+import { vestingSubgraphApi } from "../../vesting-subgraph/vestingSubgraphApi";
+import accountingApi from "../accounting/accountingApi.slice";
+import { addressBookSlice, AddressBookState } from "../addressBook/addressBook.slice";
+import { customTokensSlice, getCustomTokenId, NetworkCustomTokenState } from "../customTokens/customTokens.slice";
+import { efpApi } from "../efp/efpApi.slice";
+import { ensApi } from "../ens/ensApi.slice";
+import { lensApi } from "../lens/lensApi.slice";
+import faucetApi from "../faucet/faucetApi.slice";
+import { flagsSlice } from "../flags/flags.slice";
+import gasApi from "../gas/gasApi.slice";
+import { impersonationSlice } from "../impersonation/impersonation.slice";
+import { notificationsSlice } from "../notifications/notifications.slice";
+import { networkPreferencesSlice, NetworkPreferencesState } from "../network/networkPreferences.slice";
+import { pendingUpdateSlice } from "../pendingUpdates/pendingUpdate.slice";
+import appSettingsReducer from "../settings/appSettings.slice";
+import tokenPriceApi from "../tokenPrice/tokenPriceApi.slice";
+import { adHocRpcEndpoints } from "./endpoints/adHocRpcEndpoints";
+import { adHocSubgraphEndpoints } from "./endpoints/adHocSubgraphEndpoints";
+import { flowSchedulerEndpoints } from "./endpoints/flowSchedulerEndpoints";
 import {
-	customTokensSlice,
-	getCustomTokenId,
-	NetworkCustomTokenState,
-} from '../customTokens/customTokens.slice'
-import { ensApi } from '../ens/ensApi.slice'
-import { lensApi } from '../lens/lensApi.slice'
-import faucetApi from '../faucet/faucetApi.slice'
-import { flagsSlice } from '../flags/flags.slice'
-import gasApi from '../gas/gasApi.slice'
-import { impersonationSlice } from '../impersonation/impersonation.slice'
-import { notificationsSlice } from '../notifications/notifications.slice'
-import {
-	networkPreferencesSlice,
-	NetworkPreferencesState,
-} from '../network/networkPreferences.slice'
-import { pendingUpdateSlice } from '../pendingUpdates/pendingUpdate.slice'
-import appSettingsReducer from '../settings/appSettings.slice'
-import tokenPriceApi from '../tokenPrice/tokenPriceApi.slice'
-import { adHocRpcEndpoints } from './endpoints/adHocRpcEndpoints'
-import { adHocSubgraphEndpoints } from './endpoints/adHocSubgraphEndpoints'
-import { flowSchedulerEndpoints } from './endpoints/flowSchedulerEndpoints'
-import {
-	vestingSchedulerMutationEndpoints,
-	vestingSchedulerQueryEndpoints,
-} from './endpoints/vestingSchedulerEndpoints'
-import { platformApi } from './platformApi/platformApi'
-import addressBookRpcApi from '../addressBook/addressBookRpcApi.slice'
-import { autoWrapEndpoints } from './endpoints/autoWrapEndpoints'
-import { autoWrapSubgraphApi } from '../../auto-wrap-subgraph/autoWrapSubgraphApi'
-import { tokenAccessMutationEndpoints } from './endpoints/tokenAccessEndpoints'
-import { gdaEndpoints } from './endpoints/gdaEndpoints'
-import { deprecatedNetworkChainIds } from '../network/networks'
-import _ from 'lodash'
-import { isDefined } from '../../utils/ensureDefined'
-import { batchVestingEndpoints } from './endpoints/batchVestingEndpoints'
-import { efpApi } from '../efp/efpApi.slice'
+  vestingSchedulerMutationEndpoints,
+  vestingSchedulerQueryEndpoints,
+} from "./endpoints/vestingSchedulerEndpoints";
+import { platformApi } from "./platformApi/platformApi";
+import addressBookRpcApi from "../addressBook/addressBookRpcApi.slice";
+import { autoWrapEndpoints } from "./endpoints/autoWrapEndpoints";
+import { autoWrapSubgraphApi } from "../../auto-wrap-subgraph/autoWrapSubgraphApi";
+import { tokenAccessMutationEndpoints } from "./endpoints/tokenAccessEndpoints";
+import { gdaEndpoints } from "./endpoints/gdaEndpoints";
+import { deprecatedNetworkChainIds } from "../network/networks";
+import _ from "lodash";
+import { isDefined } from "../../utils/ensureDefined";
+import { batchVestingEndpoints } from "./endpoints/batchVestingEndpoints";
 
-export const rpcApi = initializeRpcApiSlice(options =>
-	createApiWithReactHooks({
-		...options,
-		keepUnusedDataFor: 180,
-		refetchOnMountOrArgChange: 90,
-		refetchOnReconnect: true,
-	})
+export const rpcApi = initializeRpcApiSlice((options) =>
+  createApiWithReactHooks({
+    ...options,
+    keepUnusedDataFor: 180,
+    refetchOnMountOrArgChange: 90,
+    refetchOnReconnect: true,
+  })
 )
-	.injectEndpoints(allRpcEndpoints)
-	.injectEndpoints(adHocRpcEndpoints)
-	.injectEndpoints(flowSchedulerEndpoints)
-	.injectEndpoints(vestingSchedulerMutationEndpoints)
-	.injectEndpoints(tokenAccessMutationEndpoints)
-	.injectEndpoints(vestingSchedulerQueryEndpoints)
-	.injectEndpoints(autoWrapEndpoints)
-	.injectEndpoints(gdaEndpoints)
-	.injectEndpoints(batchVestingEndpoints)
-
-export const subgraphApi = initializeSubgraphApiSlice(options =>
-	createApiWithReactHooks({
-		...options,
-		extractRehydrationInfo(action, { reducerPath }) {
-			if (
-				action.type === REHYDRATE &&
-				action.payload &&
-				action.payload[reducerPath]
-			) {
-				return action.payload[reducerPath]
-			}
-		},
-		keepUnusedDataFor: 180,
-		refetchOnMountOrArgChange: 90,
-		refetchOnReconnect: true,
-	})
+  .injectEndpoints(allRpcEndpoints)
+  .injectEndpoints(adHocRpcEndpoints)
+  .injectEndpoints(flowSchedulerEndpoints)
+  .injectEndpoints(vestingSchedulerMutationEndpoints)
+  .injectEndpoints(tokenAccessMutationEndpoints)
+  .injectEndpoints(vestingSchedulerQueryEndpoints)
+  .injectEndpoints(autoWrapEndpoints)
+  .injectEndpoints(gdaEndpoints)
+  .injectEndpoints(batchVestingEndpoints);
+  
+export const subgraphApi = initializeSubgraphApiSlice((options) =>
+  createApiWithReactHooks({
+    ...options,
+    extractRehydrationInfo(action, { reducerPath }) {
+      if (
+        action.type === REHYDRATE &&
+        action.payload &&
+        action.payload[reducerPath]
+      ) {
+        return action.payload[reducerPath];
+      }
+    },
+    keepUnusedDataFor: 180,
+    refetchOnMountOrArgChange: 90,
+    refetchOnReconnect: true,
+  })
 )
-	.injectEndpoints(allSubgraphEndpoints)
-	.injectEndpoints(adHocSubgraphEndpoints)
+  .injectEndpoints(allSubgraphEndpoints)
+  .injectEndpoints(adHocSubgraphEndpoints);
 
-export const transactionTracker = initializeTransactionTrackerSlice()
+export const transactionTracker = initializeTransactionTrackerSlice();
 
 const transactionTrackerPersistedReducer = persistReducer(
-	{
-		storage,
-		key: 'transactions',
-		version: 2,
-		migrate: async (persistedState, currentVersion) => {
-			if (persistedState && currentVersion === 1) {
-				const oldState = persistedState as PersistedState &
-					EntityState<TrackedTransaction>
-				const transactionsToRemove = Object.values(oldState.entities)
-					.filter(isDefined)
-					.filter(x =>
-						deprecatedNetworkChainIds.includes(x.chainId)
-					) as TrackedTransaction[]
-				const newEntities = { ...oldState.entities }
-				for (const tx of transactionsToRemove) {
-					delete newEntities[tx.hash]
-				}
-				return {
-					...oldState,
-					entities: newEntities,
-					ids: Object.values(newEntities)
-						.filter(isDefined)
-						.map(x => x.hash),
-				}
-			}
-			return persistedState
-		},
-	},
-	transactionTracker.reducer
-)
+  { storage, key: "transactions", version: 2, migrate: async (persistedState, currentVersion) => {
+    if (persistedState && currentVersion === 1) {
+      const oldState = persistedState as PersistedState & EntityState<TrackedTransaction>;
+      const transactionsToRemove = Object.values(oldState.entities).filter(isDefined).filter(x => deprecatedNetworkChainIds.includes(x.chainId)) as TrackedTransaction[];
+      const newEntities = { ...oldState.entities };
+      for (const tx of transactionsToRemove) {
+        delete newEntities[tx.hash];
+      }
+      return {
+        ...oldState,
+        entities: newEntities,
+        ids: Object.values(newEntities).filter(isDefined).map(x => x.hash)
+      }
+    }
+    return persistedState;
+  } },
+  transactionTracker.reducer
+);
 
 const impersonationPersistedReducer = persistReducer(
-	{ storage, key: 'impersonations', version: 1 },
-	impersonationSlice.reducer
-)
+  { storage, key: "impersonations", version: 1 },
+  impersonationSlice.reducer
+);
 
 const addressBookPersistedReducer = persistReducer(
-	{
-		storage,
-		key: 'addressBook',
-		version: 2,
-		migrate: async (persistedState, currentVersion) => {
-			if (persistedState && currentVersion === 1) {
-				const oldState = persistedState as PersistedState &
-					AddressBookState
-				const newEntities = { ...oldState.entities }
-				Object.values(newEntities)
-					.filter(isDefined)
-					.forEach(x => {
-						if (x.associatedNetworks?.length) {
-							x.associatedNetworks = _.without(
-								x.associatedNetworks,
-								...deprecatedNetworkChainIds
-							)
-						}
-					})
-				return {
-					...oldState,
-					entities: newEntities,
-				}
-			}
-			return persistedState
-		},
-	},
-	addressBookSlice.reducer
-)
+  { storage, key: "addressBook", version: 2, migrate: async (persistedState, currentVersion) => {
+    if (persistedState && currentVersion === 1) {
+      const oldState = persistedState as PersistedState & AddressBookState;
+      const newEntities = { ...oldState.entities };
+      Object.values(newEntities).filter(isDefined).forEach((x) => {
+        if (x.associatedNetworks?.length) {
+          x.associatedNetworks = _.without(x.associatedNetworks, ...deprecatedNetworkChainIds);
+        }
+      });
+      return {
+        ...oldState,
+        entities: newEntities,
+      }
+    }
+    return persistedState;
+  } },
+  addressBookSlice.reducer
+);
 
 const customTokensPersistedReducer = persistReducer(
-	{
-		storage,
-		key: 'customTokens',
-		version: 2,
-		migrate: async (persistedState, currentVersion) => {
-			if (persistedState && currentVersion === 1) {
-				const oldState = persistedState as PersistedState &
-					NetworkCustomTokenState
-				const newEntities = { ...oldState.entities }
-				Object.values(newEntities).forEach(x => {
-					if (x && deprecatedNetworkChainIds.includes(x.chainId)) {
-						delete newEntities[x.customToken]
-					}
-				})
-				return {
-					...oldState,
-					entities: newEntities,
-					ids: Object.values(newEntities)
-						.filter(isDefined)
-						.map(x => getCustomTokenId(x.chainId, x.customToken)),
-				}
-			}
-			return persistedState
-		},
-	},
-	customTokensSlice.reducer
-)
+  { storage, key: "customTokens", version: 2, migrate: async (persistedState, currentVersion) => {
+    if (persistedState && currentVersion === 1) {
+      const oldState = persistedState as PersistedState & NetworkCustomTokenState;
+      const newEntities = { ...oldState.entities };
+      Object.values(newEntities).forEach((x) => {
+        if (x && deprecatedNetworkChainIds.includes(x.chainId)) {
+          delete newEntities[x.customToken];
+        }
+      });
+      return {
+        ...oldState,
+        entities: newEntities,
+        ids: Object.values(newEntities).filter(isDefined).map(x => getCustomTokenId(x.chainId, x.customToken))
+      }
+    }
+    return persistedState;
+  } },
+  customTokensSlice.reducer
+);
 
 const networkPreferencesPersistedReducer = persistReducer(
-	{
-		storage,
-		key: 'networkPreferences',
-		version: 2,
-		migrate: async (persistedState, currentVersion) => {
-			if (persistedState && currentVersion === 1) {
-				const oldState = persistedState as PersistedState &
-					NetworkPreferencesState
-				const newEntities = { ...oldState.entities }
-				Object.values(newEntities).forEach(x => {
-					if (x?.hidden) {
-						x.hidden = _.without(
-							x.hidden,
-							...deprecatedNetworkChainIds
-						)
-					}
-				})
-				return {
-					...oldState,
-					entities: newEntities,
-				}
-			}
-		},
-	},
-	networkPreferencesSlice.reducer
-)
+  { storage, key: "networkPreferences", version: 2, migrate: async (persistedState, currentVersion) => {
+    if (persistedState && currentVersion === 1) {
+      const oldState = persistedState as PersistedState & NetworkPreferencesState;
+      const newEntities = { ...oldState.entities };
+      Object.values(newEntities).forEach((x) => {
+        if (x?.hidden) {
+          x.hidden = _.without(x.hidden, ...deprecatedNetworkChainIds);
+        }
+      });
+      return {
+        ...oldState,
+        entities: newEntities
+      }
+    }
+  } },
+  networkPreferencesSlice.reducer
+);
 
 const flagsPersistedReducer = persistReducer(
-	{ storage, key: 'flags', version: 1 },
-	flagsSlice.reducer
-)
+  { storage, key: "flags", version: 1 },
+  flagsSlice.reducer
+);
 
 const appSettingsPersistedReducer = persistReducer(
-	{ storage, key: 'appSettings', version: 1 },
-	appSettingsReducer
-)
+  { storage, key: "appSettings", version: 1 },
+  appSettingsReducer
+);
 
 const notificatonsPersistedReducer = persistReducer(
-	{ storage, key: 'notifications', version: 1 },
-	notificationsSlice.reducer
-)
+  { storage, key: "notifications", version: 1 },
+  notificationsSlice.reducer
+);
 
-export const listenerMiddleware = createListenerMiddleware()
+export const listenerMiddleware = createListenerMiddleware();
 
 export const sentryErrorLogger: Middleware =
-	(api: MiddlewareAPI) => next => action => {
-		const { error } = action
+  (api: MiddlewareAPI) => (next) => (action) => {
+    const { error } = action;
 
-		// Log when there was an error/exception but it wasn't explicitly rejected.
-		if (error && isRejected(action) && !isRejectedWithValue(action)) {
-			// "aborted" & "condition" inspired by: https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/createAsyncThunk.ts#L521
-			const aborted = error?.name === 'AbortError'
-			const condition = error?.name === 'ConditionError'
-			if (!aborted && !condition) {
-				try {
-					const deserializedError = deserializeError(error) // We need to deserialize the error because RTK has already turned it into a "SerializedError" here. We prefer the deserialized error because Sentry works a lot better with an Error object.
+    // Log when there was an error/exception but it wasn't explicitly rejected.
+    if (error && isRejected(action) && !isRejectedWithValue(action)) {
+      // "aborted" & "condition" inspired by: https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/createAsyncThunk.ts#L521
+      const aborted = error?.name === "AbortError";
+      const condition = error?.name === "ConditionError";
+      if (!aborted && !condition) {
+        try {
+          const deserializedError = deserializeError(error); // We need to deserialize the error because RTK has already turned it into a "SerializedError" here. We prefer the deserialized error because Sentry works a lot better with an Error object.
 
-					const errorMessage = (
-						deserializedError as { message?: string }
-					).message
-					const ethersV5ErrorParts = (errorMessage ?? '').split(
-						' [ See: https://links.ethers.org/v5-errors-'
-					) // https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/logger/src.ts/index.ts#L261
-					const isEthersV5Error = ethersV5ErrorParts.length === 2
+          const errorMessage = (deserializedError as { message?: string })
+            .message;
+          const ethersV5ErrorParts = (errorMessage ?? "").split(
+            " [ See: https://links.ethers.org/v5-errors-"
+          ); // https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/logger/src.ts/index.ts#L261
+          const isEthersV5Error = ethersV5ErrorParts.length === 2;
 
-					if (isEthersV5Error) {
-						;(deserializedError as { message: string }).message =
-							ethersV5ErrorParts[0] // Shorten ethers error message to just "reason".
-					}
+          if (isEthersV5Error) {
+            (deserializedError as { message: string }).message =
+              ethersV5ErrorParts[0]; // Shorten ethers error message to just "reason".
+          }
 
-					const isUserRejectedRequest =
-						(deserializedError as { code?: string }).code ===
-						'ACTION_REJECTED' // Inspired by wagmi: https://github.com/wagmi-dev/wagmi/blob/348148b4048e4c6cb930a03b88a7aebe2fad4121/packages/core/src/actions/transactions/sendTransaction.ts#L105 & ethers: https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/logger/src.ts/index.ts#L156
-					if (!isUserRejectedRequest) {
-						Sentry.captureException(deserializedError)
-					}
-				} catch (e) {
-					Sentry.captureException(e) // If deserialization failed, let's not break the Redux middleware chain. This should never happen though.
-				}
-			}
-		}
-		return next(action)
-	}
+          const isUserRejectedRequest =
+            (deserializedError as { code?: string }).code === "ACTION_REJECTED"; // Inspired by wagmi: https://github.com/wagmi-dev/wagmi/blob/348148b4048e4c6cb930a03b88a7aebe2fad4121/packages/core/src/actions/transactions/sendTransaction.ts#L105 & ethers: https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/logger/src.ts/index.ts#L156
+          if (!isUserRejectedRequest) {
+            Sentry.captureException(deserializedError);
+          }
+        } catch (e) {
+          Sentry.captureException(e); // If deserialization failed, let's not break the Redux middleware chain. This should never happen though.
+        }
+      }
+    }
+    return next(action);
+  };
 
 export const reduxStore = configureStore({
-	reducer: {
-		// API slices
-		[rpcApi.reducerPath]: rpcApi.reducer,
-		[subgraphApi.reducerPath]: subgraphApi.reducer,
-		[transactionTracker.reducerPath]: transactionTrackerPersistedReducer,
-		[efpApi.reducerPath]: efpApi.reducer,
-		[ensApi.reducerPath]: ensApi.reducer,
-		[lensApi.reducerPath]: lensApi.reducer,
-		[gasApi.reducerPath]: gasApi.reducer,
-		[platformApi.reducerPath]: platformApi.reducer,
-		[faucetApi.reducerPath]: faucetApi.reducer,
-		[tokenPriceApi.reducerPath]: tokenPriceApi.reducer,
-		[accountingApi.reducerPath]: accountingApi.reducer,
-		[vestingSubgraphApi.reducerPath]: vestingSubgraphApi.reducer,
-		[autoWrapSubgraphApi.reducerPath]: autoWrapSubgraphApi.reducer,
-		[schedulingSubgraphApi.reducerPath]: schedulingSubgraphApi.reducer,
-		[addressBookRpcApi.reducerPath]: addressBookRpcApi.reducer,
+  reducer: {
+    // API slices
+    [rpcApi.reducerPath]: rpcApi.reducer,
+    [subgraphApi.reducerPath]: subgraphApi.reducer,
+    [transactionTracker.reducerPath]: transactionTrackerPersistedReducer,
+    [efpApi.reducerPath]: efpApi.reducer,
+    [ensApi.reducerPath]: ensApi.reducer,
+    [lensApi.reducerPath]: lensApi.reducer,
+    [gasApi.reducerPath]: gasApi.reducer,
+    [platformApi.reducerPath]: platformApi.reducer,
+    [faucetApi.reducerPath]: faucetApi.reducer,
+    [tokenPriceApi.reducerPath]: tokenPriceApi.reducer,
+    [accountingApi.reducerPath]: accountingApi.reducer,
+    [vestingSubgraphApi.reducerPath]: vestingSubgraphApi.reducer,
+    [autoWrapSubgraphApi.reducerPath]: autoWrapSubgraphApi.reducer,
+    [schedulingSubgraphApi.reducerPath]: schedulingSubgraphApi.reducer,
+    [addressBookRpcApi.reducerPath]: addressBookRpcApi.reducer,
 
-		// Persisted slices
-		appSettings: appSettingsPersistedReducer,
-		impersonations: impersonationPersistedReducer,
-		addressBook: addressBookPersistedReducer,
-		customTokens: customTokensPersistedReducer,
-		networkPreferences: networkPreferencesPersistedReducer,
-		notifications: notificatonsPersistedReducer,
-		flags: flagsPersistedReducer,
+    // Persisted slices
+    appSettings: appSettingsPersistedReducer,
+    impersonations: impersonationPersistedReducer,
+    addressBook: addressBookPersistedReducer,
+    customTokens: customTokensPersistedReducer,
+    networkPreferences: networkPreferencesPersistedReducer,
+    notifications: notificatonsPersistedReducer,
+    flags: flagsPersistedReducer,
 
-		// Default slices
-		pendingUpdates: pendingUpdateSlice.reducer,
-	},
-	enhancers: existingEnhancers =>
-		existingEnhancers.concat(
-			autoBatchEnhancer({
-				type: typeof window !== 'undefined' ? 'raf' : 'tick',
-			})
-		), // https://redux-toolkit.js.org/api/autoBatchEnhancer#autobatchenhancer-1
-	middleware: getDefaultMiddleware =>
-		getDefaultMiddleware({
-			serializableCheck: {
-				ignoredActions: [
-					FLUSH,
-					REHYDRATE,
-					PAUSE,
-					PERSIST,
-					PURGE,
-					REGISTER,
-				], // Ignore redux-persist actions: https://stackoverflow.com/a/62610422
-			},
-		})
-			.prepend(listenerMiddleware.middleware)
-			.prepend(sentryErrorLogger)
-			.concat(rpcApi.middleware)
-			.concat(vestingSubgraphApi.middleware)
-			.concat(autoWrapSubgraphApi.middleware)
-			.concat(schedulingSubgraphApi.middleware)
-			.concat(subgraphApi.middleware)
-			.concat(efpApi.middleware)
-			.concat(ensApi.middleware)
-			.concat(lensApi.middleware)
-			.concat(gasApi.middleware)
-			.concat(platformApi.middleware)
-			.concat(faucetApi.middleware)
-			.concat(tokenPriceApi.middleware)
-			.concat(accountingApi.middleware)
-			.concat(addressBookRpcApi.middleware),
-})
+    // Default slices
+    pendingUpdates: pendingUpdateSlice.reducer,
+  },
+  enhancers: (existingEnhancers) =>
+    existingEnhancers.concat(
+      autoBatchEnhancer({
+        type: typeof window !== "undefined" ? "raf" : "tick",
+      })
+    ), // https://redux-toolkit.js.org/api/autoBatchEnhancer#autobatchenhancer-1
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER], // Ignore redux-persist actions: https://stackoverflow.com/a/62610422
+      },
+    })
+      .prepend(listenerMiddleware.middleware)
+      .prepend(sentryErrorLogger)
+      .concat(rpcApi.middleware)
+      .concat(vestingSubgraphApi.middleware)
+      .concat(autoWrapSubgraphApi.middleware)
+      .concat(schedulingSubgraphApi.middleware)
+      .concat(subgraphApi.middleware)
+      .concat(efpApi.middleware)
+      .concat(ensApi.middleware)
+      .concat(lensApi.middleware)
+      .concat(gasApi.middleware)
+      .concat(platformApi.middleware)
+      .concat(faucetApi.middleware)
+      .concat(tokenPriceApi.middleware)
+      .concat(accountingApi.middleware)
+      .concat(addressBookRpcApi.middleware),
+});
 
-export const reduxPersistor = persistStore(reduxStore)
+export const reduxPersistor = persistStore(reduxStore);
 
 // optional, but required for refetchOnFocus/refetchOnReconnect behaviors of RTK-Query
-setupListeners(reduxStore.dispatch)
+setupListeners(reduxStore.dispatch);
 
-export type AppStore = typeof reduxStore
-export type RootState = ReturnType<AppStore['getState']>
-export type AppDispatch = AppStore['dispatch']
+export type AppStore = typeof reduxStore;
+export type RootState = ReturnType<AppStore["getState"]>;
+export type AppDispatch = AppStore["dispatch"];
 
-export const useAppDispatch = () => useDispatch<AppDispatch>()
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/features/redux/store.ts
+++ b/src/features/redux/store.ts
@@ -1,321 +1,381 @@
 import {
-  autoBatchEnhancer,
-  configureStore,
-  createListenerMiddleware,
-  EntityState,
-  isRejected,
-  isRejectedWithValue,
-  Middleware,
-  MiddlewareAPI,
-} from "@reduxjs/toolkit";
+	autoBatchEnhancer,
+	configureStore,
+	createListenerMiddleware,
+	EntityState,
+	isRejected,
+	isRejectedWithValue,
+	Middleware,
+	MiddlewareAPI,
+} from '@reduxjs/toolkit'
+import { setupListeners } from '@reduxjs/toolkit/query'
+import * as Sentry from '@sentry/react'
 import {
-  setupListeners,
-} from "@reduxjs/toolkit/query";
-import * as Sentry from "@sentry/react";
+	allRpcEndpoints,
+	allSubgraphEndpoints,
+	createApiWithReactHooks,
+	initializeRpcApiSlice,
+	initializeSubgraphApiSlice,
+	initializeTransactionTrackerSlice,
+	TrackedTransaction,
+} from '@superfluid-finance/sdk-redux'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import {
-  allRpcEndpoints,
-  allSubgraphEndpoints,
-  createApiWithReactHooks,
-  initializeRpcApiSlice,
-  initializeSubgraphApiSlice,
-  initializeTransactionTrackerSlice,
-  TrackedTransaction,
-} from "@superfluid-finance/sdk-redux";
-import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+	FLUSH,
+	PAUSE,
+	PERSIST,
+	PersistedState,
+	persistReducer,
+	persistStore,
+	PURGE,
+	REGISTER,
+	REHYDRATE,
+} from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+import { deserializeError } from 'serialize-error'
+import { schedulingSubgraphApi } from '../../scheduling-subgraph/schedulingSubgraphApi'
+import { vestingSubgraphApi } from '../../vesting-subgraph/vestingSubgraphApi'
+import accountingApi from '../accounting/accountingApi.slice'
 import {
-  FLUSH,
-  PAUSE,
-  PERSIST,
-  PersistedState,
-  persistReducer,
-  persistStore,
-  PURGE,
-  REGISTER,
-  REHYDRATE,
-} from "redux-persist";
-import storage from "redux-persist/lib/storage";
-import { deserializeError } from "serialize-error";
-import { schedulingSubgraphApi } from "../../scheduling-subgraph/schedulingSubgraphApi";
-import { vestingSubgraphApi } from "../../vesting-subgraph/vestingSubgraphApi";
-import accountingApi from "../accounting/accountingApi.slice";
-import { addressBookSlice, AddressBookState } from "../addressBook/addressBook.slice";
-import { customTokensSlice, getCustomTokenId, NetworkCustomTokenState } from "../customTokens/customTokens.slice";
-import { ensApi } from "../ens/ensApi.slice";
-import { lensApi } from "../lens/lensApi.slice";
-import faucetApi from "../faucet/faucetApi.slice";
-import { flagsSlice } from "../flags/flags.slice";
-import gasApi from "../gas/gasApi.slice";
-import { impersonationSlice } from "../impersonation/impersonation.slice";
-import { notificationsSlice } from "../notifications/notifications.slice";
-import { networkPreferencesSlice, NetworkPreferencesState } from "../network/networkPreferences.slice";
-import { pendingUpdateSlice } from "../pendingUpdates/pendingUpdate.slice";
-import appSettingsReducer from "../settings/appSettings.slice";
-import tokenPriceApi from "../tokenPrice/tokenPriceApi.slice";
-import { adHocRpcEndpoints } from "./endpoints/adHocRpcEndpoints";
-import { adHocSubgraphEndpoints } from "./endpoints/adHocSubgraphEndpoints";
-import { flowSchedulerEndpoints } from "./endpoints/flowSchedulerEndpoints";
+	addressBookSlice,
+	AddressBookState,
+} from '../addressBook/addressBook.slice'
 import {
-  vestingSchedulerMutationEndpoints,
-  vestingSchedulerQueryEndpoints,
-} from "./endpoints/vestingSchedulerEndpoints";
-import { platformApi } from "./platformApi/platformApi";
-import addressBookRpcApi from "../addressBook/addressBookRpcApi.slice";
-import { autoWrapEndpoints } from "./endpoints/autoWrapEndpoints";
-import { autoWrapSubgraphApi } from "../../auto-wrap-subgraph/autoWrapSubgraphApi";
-import { tokenAccessMutationEndpoints } from "./endpoints/tokenAccessEndpoints";
-import { gdaEndpoints } from "./endpoints/gdaEndpoints";
-import { deprecatedNetworkChainIds } from "../network/networks";
-import _ from "lodash";
-import { isDefined } from "../../utils/ensureDefined";
-import { batchVestingEndpoints } from "./endpoints/batchVestingEndpoints";
+	customTokensSlice,
+	getCustomTokenId,
+	NetworkCustomTokenState,
+} from '../customTokens/customTokens.slice'
+import { ensApi } from '../ens/ensApi.slice'
+import { lensApi } from '../lens/lensApi.slice'
+import faucetApi from '../faucet/faucetApi.slice'
+import { flagsSlice } from '../flags/flags.slice'
+import gasApi from '../gas/gasApi.slice'
+import { impersonationSlice } from '../impersonation/impersonation.slice'
+import { notificationsSlice } from '../notifications/notifications.slice'
+import {
+	networkPreferencesSlice,
+	NetworkPreferencesState,
+} from '../network/networkPreferences.slice'
+import { pendingUpdateSlice } from '../pendingUpdates/pendingUpdate.slice'
+import appSettingsReducer from '../settings/appSettings.slice'
+import tokenPriceApi from '../tokenPrice/tokenPriceApi.slice'
+import { adHocRpcEndpoints } from './endpoints/adHocRpcEndpoints'
+import { adHocSubgraphEndpoints } from './endpoints/adHocSubgraphEndpoints'
+import { flowSchedulerEndpoints } from './endpoints/flowSchedulerEndpoints'
+import {
+	vestingSchedulerMutationEndpoints,
+	vestingSchedulerQueryEndpoints,
+} from './endpoints/vestingSchedulerEndpoints'
+import { platformApi } from './platformApi/platformApi'
+import addressBookRpcApi from '../addressBook/addressBookRpcApi.slice'
+import { autoWrapEndpoints } from './endpoints/autoWrapEndpoints'
+import { autoWrapSubgraphApi } from '../../auto-wrap-subgraph/autoWrapSubgraphApi'
+import { tokenAccessMutationEndpoints } from './endpoints/tokenAccessEndpoints'
+import { gdaEndpoints } from './endpoints/gdaEndpoints'
+import { deprecatedNetworkChainIds } from '../network/networks'
+import _ from 'lodash'
+import { isDefined } from '../../utils/ensureDefined'
+import { batchVestingEndpoints } from './endpoints/batchVestingEndpoints'
+import { efpApi } from '../efp/efpApi.slice'
 
-export const rpcApi = initializeRpcApiSlice((options) =>
-  createApiWithReactHooks({
-    ...options,
-    keepUnusedDataFor: 180,
-    refetchOnMountOrArgChange: 90,
-    refetchOnReconnect: true,
-  })
+export const rpcApi = initializeRpcApiSlice(options =>
+	createApiWithReactHooks({
+		...options,
+		keepUnusedDataFor: 180,
+		refetchOnMountOrArgChange: 90,
+		refetchOnReconnect: true,
+	})
 )
-  .injectEndpoints(allRpcEndpoints)
-  .injectEndpoints(adHocRpcEndpoints)
-  .injectEndpoints(flowSchedulerEndpoints)
-  .injectEndpoints(vestingSchedulerMutationEndpoints)
-  .injectEndpoints(tokenAccessMutationEndpoints)
-  .injectEndpoints(vestingSchedulerQueryEndpoints)
-  .injectEndpoints(autoWrapEndpoints)
-  .injectEndpoints(gdaEndpoints)
-  .injectEndpoints(batchVestingEndpoints);
-  
-export const subgraphApi = initializeSubgraphApiSlice((options) =>
-  createApiWithReactHooks({
-    ...options,
-    extractRehydrationInfo(action, { reducerPath }) {
-      if (
-        action.type === REHYDRATE &&
-        action.payload &&
-        action.payload[reducerPath]
-      ) {
-        return action.payload[reducerPath];
-      }
-    },
-    keepUnusedDataFor: 180,
-    refetchOnMountOrArgChange: 90,
-    refetchOnReconnect: true,
-  })
-)
-  .injectEndpoints(allSubgraphEndpoints)
-  .injectEndpoints(adHocSubgraphEndpoints);
+	.injectEndpoints(allRpcEndpoints)
+	.injectEndpoints(adHocRpcEndpoints)
+	.injectEndpoints(flowSchedulerEndpoints)
+	.injectEndpoints(vestingSchedulerMutationEndpoints)
+	.injectEndpoints(tokenAccessMutationEndpoints)
+	.injectEndpoints(vestingSchedulerQueryEndpoints)
+	.injectEndpoints(autoWrapEndpoints)
+	.injectEndpoints(gdaEndpoints)
+	.injectEndpoints(batchVestingEndpoints)
 
-export const transactionTracker = initializeTransactionTrackerSlice();
+export const subgraphApi = initializeSubgraphApiSlice(options =>
+	createApiWithReactHooks({
+		...options,
+		extractRehydrationInfo(action, { reducerPath }) {
+			if (
+				action.type === REHYDRATE &&
+				action.payload &&
+				action.payload[reducerPath]
+			) {
+				return action.payload[reducerPath]
+			}
+		},
+		keepUnusedDataFor: 180,
+		refetchOnMountOrArgChange: 90,
+		refetchOnReconnect: true,
+	})
+)
+	.injectEndpoints(allSubgraphEndpoints)
+	.injectEndpoints(adHocSubgraphEndpoints)
+
+export const transactionTracker = initializeTransactionTrackerSlice()
 
 const transactionTrackerPersistedReducer = persistReducer(
-  { storage, key: "transactions", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
-      const oldState = persistedState as PersistedState & EntityState<TrackedTransaction>;
-      const transactionsToRemove = Object.values(oldState.entities).filter(isDefined).filter(x => deprecatedNetworkChainIds.includes(x.chainId)) as TrackedTransaction[];
-      const newEntities = { ...oldState.entities };
-      for (const tx of transactionsToRemove) {
-        delete newEntities[tx.hash];
-      }
-      return {
-        ...oldState,
-        entities: newEntities,
-        ids: Object.values(newEntities).filter(isDefined).map(x => x.hash)
-      }
-    }
-    return persistedState;
-  } },
-  transactionTracker.reducer
-);
+	{
+		storage,
+		key: 'transactions',
+		version: 2,
+		migrate: async (persistedState, currentVersion) => {
+			if (persistedState && currentVersion === 1) {
+				const oldState = persistedState as PersistedState &
+					EntityState<TrackedTransaction>
+				const transactionsToRemove = Object.values(oldState.entities)
+					.filter(isDefined)
+					.filter(x =>
+						deprecatedNetworkChainIds.includes(x.chainId)
+					) as TrackedTransaction[]
+				const newEntities = { ...oldState.entities }
+				for (const tx of transactionsToRemove) {
+					delete newEntities[tx.hash]
+				}
+				return {
+					...oldState,
+					entities: newEntities,
+					ids: Object.values(newEntities)
+						.filter(isDefined)
+						.map(x => x.hash),
+				}
+			}
+			return persistedState
+		},
+	},
+	transactionTracker.reducer
+)
 
 const impersonationPersistedReducer = persistReducer(
-  { storage, key: "impersonations", version: 1 },
-  impersonationSlice.reducer
-);
+	{ storage, key: 'impersonations', version: 1 },
+	impersonationSlice.reducer
+)
 
 const addressBookPersistedReducer = persistReducer(
-  { storage, key: "addressBook", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
-      const oldState = persistedState as PersistedState & AddressBookState;
-      const newEntities = { ...oldState.entities };
-      Object.values(newEntities).filter(isDefined).forEach((x) => {
-        if (x.associatedNetworks?.length) {
-          x.associatedNetworks = _.without(x.associatedNetworks, ...deprecatedNetworkChainIds);
-        }
-      });
-      return {
-        ...oldState,
-        entities: newEntities,
-      }
-    }
-    return persistedState;
-  } },
-  addressBookSlice.reducer
-);
+	{
+		storage,
+		key: 'addressBook',
+		version: 2,
+		migrate: async (persistedState, currentVersion) => {
+			if (persistedState && currentVersion === 1) {
+				const oldState = persistedState as PersistedState &
+					AddressBookState
+				const newEntities = { ...oldState.entities }
+				Object.values(newEntities)
+					.filter(isDefined)
+					.forEach(x => {
+						if (x.associatedNetworks?.length) {
+							x.associatedNetworks = _.without(
+								x.associatedNetworks,
+								...deprecatedNetworkChainIds
+							)
+						}
+					})
+				return {
+					...oldState,
+					entities: newEntities,
+				}
+			}
+			return persistedState
+		},
+	},
+	addressBookSlice.reducer
+)
 
 const customTokensPersistedReducer = persistReducer(
-  { storage, key: "customTokens", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
-      const oldState = persistedState as PersistedState & NetworkCustomTokenState;
-      const newEntities = { ...oldState.entities };
-      Object.values(newEntities).forEach((x) => {
-        if (x && deprecatedNetworkChainIds.includes(x.chainId)) {
-          delete newEntities[x.customToken];
-        }
-      });
-      return {
-        ...oldState,
-        entities: newEntities,
-        ids: Object.values(newEntities).filter(isDefined).map(x => getCustomTokenId(x.chainId, x.customToken))
-      }
-    }
-    return persistedState;
-  } },
-  customTokensSlice.reducer
-);
+	{
+		storage,
+		key: 'customTokens',
+		version: 2,
+		migrate: async (persistedState, currentVersion) => {
+			if (persistedState && currentVersion === 1) {
+				const oldState = persistedState as PersistedState &
+					NetworkCustomTokenState
+				const newEntities = { ...oldState.entities }
+				Object.values(newEntities).forEach(x => {
+					if (x && deprecatedNetworkChainIds.includes(x.chainId)) {
+						delete newEntities[x.customToken]
+					}
+				})
+				return {
+					...oldState,
+					entities: newEntities,
+					ids: Object.values(newEntities)
+						.filter(isDefined)
+						.map(x => getCustomTokenId(x.chainId, x.customToken)),
+				}
+			}
+			return persistedState
+		},
+	},
+	customTokensSlice.reducer
+)
 
 const networkPreferencesPersistedReducer = persistReducer(
-  { storage, key: "networkPreferences", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
-      const oldState = persistedState as PersistedState & NetworkPreferencesState;
-      const newEntities = { ...oldState.entities };
-      Object.values(newEntities).forEach((x) => {
-        if (x?.hidden) {
-          x.hidden = _.without(x.hidden, ...deprecatedNetworkChainIds);
-        }
-      });
-      return {
-        ...oldState,
-        entities: newEntities
-      }
-    }
-  } },
-  networkPreferencesSlice.reducer
-);
+	{
+		storage,
+		key: 'networkPreferences',
+		version: 2,
+		migrate: async (persistedState, currentVersion) => {
+			if (persistedState && currentVersion === 1) {
+				const oldState = persistedState as PersistedState &
+					NetworkPreferencesState
+				const newEntities = { ...oldState.entities }
+				Object.values(newEntities).forEach(x => {
+					if (x?.hidden) {
+						x.hidden = _.without(
+							x.hidden,
+							...deprecatedNetworkChainIds
+						)
+					}
+				})
+				return {
+					...oldState,
+					entities: newEntities,
+				}
+			}
+		},
+	},
+	networkPreferencesSlice.reducer
+)
 
 const flagsPersistedReducer = persistReducer(
-  { storage, key: "flags", version: 1 },
-  flagsSlice.reducer
-);
+	{ storage, key: 'flags', version: 1 },
+	flagsSlice.reducer
+)
 
 const appSettingsPersistedReducer = persistReducer(
-  { storage, key: "appSettings", version: 1 },
-  appSettingsReducer
-);
+	{ storage, key: 'appSettings', version: 1 },
+	appSettingsReducer
+)
 
 const notificatonsPersistedReducer = persistReducer(
-  { storage, key: "notifications", version: 1 },
-  notificationsSlice.reducer
-);
+	{ storage, key: 'notifications', version: 1 },
+	notificationsSlice.reducer
+)
 
-export const listenerMiddleware = createListenerMiddleware();
+export const listenerMiddleware = createListenerMiddleware()
 
 export const sentryErrorLogger: Middleware =
-  (api: MiddlewareAPI) => (next) => (action) => {
-    const { error } = action;
+	(api: MiddlewareAPI) => next => action => {
+		const { error } = action
 
-    // Log when there was an error/exception but it wasn't explicitly rejected.
-    if (error && isRejected(action) && !isRejectedWithValue(action)) {
-      // "aborted" & "condition" inspired by: https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/createAsyncThunk.ts#L521
-      const aborted = error?.name === "AbortError";
-      const condition = error?.name === "ConditionError";
-      if (!aborted && !condition) {
-        try {
-          const deserializedError = deserializeError(error); // We need to deserialize the error because RTK has already turned it into a "SerializedError" here. We prefer the deserialized error because Sentry works a lot better with an Error object.
+		// Log when there was an error/exception but it wasn't explicitly rejected.
+		if (error && isRejected(action) && !isRejectedWithValue(action)) {
+			// "aborted" & "condition" inspired by: https://github.com/reduxjs/redux-toolkit/blob/64a30d83384d77bcbc59231fa32aa2f1acd67020/packages/toolkit/src/createAsyncThunk.ts#L521
+			const aborted = error?.name === 'AbortError'
+			const condition = error?.name === 'ConditionError'
+			if (!aborted && !condition) {
+				try {
+					const deserializedError = deserializeError(error) // We need to deserialize the error because RTK has already turned it into a "SerializedError" here. We prefer the deserialized error because Sentry works a lot better with an Error object.
 
-          const errorMessage = (deserializedError as { message?: string })
-            .message;
-          const ethersV5ErrorParts = (errorMessage ?? "").split(
-            " [ See: https://links.ethers.org/v5-errors-"
-          ); // https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/logger/src.ts/index.ts#L261
-          const isEthersV5Error = ethersV5ErrorParts.length === 2;
+					const errorMessage = (
+						deserializedError as { message?: string }
+					).message
+					const ethersV5ErrorParts = (errorMessage ?? '').split(
+						' [ See: https://links.ethers.org/v5-errors-'
+					) // https://github.com/ethers-io/ethers.js/blob/c80fcddf50a9023486e9f9acb1848aba4c19f7b6/packages/logger/src.ts/index.ts#L261
+					const isEthersV5Error = ethersV5ErrorParts.length === 2
 
-          if (isEthersV5Error) {
-            (deserializedError as { message: string }).message =
-              ethersV5ErrorParts[0]; // Shorten ethers error message to just "reason".
-          }
+					if (isEthersV5Error) {
+						;(deserializedError as { message: string }).message =
+							ethersV5ErrorParts[0] // Shorten ethers error message to just "reason".
+					}
 
-          const isUserRejectedRequest =
-            (deserializedError as { code?: string }).code === "ACTION_REJECTED"; // Inspired by wagmi: https://github.com/wagmi-dev/wagmi/blob/348148b4048e4c6cb930a03b88a7aebe2fad4121/packages/core/src/actions/transactions/sendTransaction.ts#L105 & ethers: https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/logger/src.ts/index.ts#L156
-          if (!isUserRejectedRequest) {
-            Sentry.captureException(deserializedError);
-          }
-        } catch (e) {
-          Sentry.captureException(e); // If deserialization failed, let's not break the Redux middleware chain. This should never happen though.
-        }
-      }
-    }
-    return next(action);
-  };
+					const isUserRejectedRequest =
+						(deserializedError as { code?: string }).code ===
+						'ACTION_REJECTED' // Inspired by wagmi: https://github.com/wagmi-dev/wagmi/blob/348148b4048e4c6cb930a03b88a7aebe2fad4121/packages/core/src/actions/transactions/sendTransaction.ts#L105 & ethers: https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/logger/src.ts/index.ts#L156
+					if (!isUserRejectedRequest) {
+						Sentry.captureException(deserializedError)
+					}
+				} catch (e) {
+					Sentry.captureException(e) // If deserialization failed, let's not break the Redux middleware chain. This should never happen though.
+				}
+			}
+		}
+		return next(action)
+	}
 
 export const reduxStore = configureStore({
-  reducer: {
-    // API slices
-    [rpcApi.reducerPath]: rpcApi.reducer,
-    [subgraphApi.reducerPath]: subgraphApi.reducer,
-    [transactionTracker.reducerPath]: transactionTrackerPersistedReducer,
-    [ensApi.reducerPath]: ensApi.reducer,
-    [lensApi.reducerPath]: lensApi.reducer,
-    [gasApi.reducerPath]: gasApi.reducer,
-    [platformApi.reducerPath]: platformApi.reducer,
-    [faucetApi.reducerPath]: faucetApi.reducer,
-    [tokenPriceApi.reducerPath]: tokenPriceApi.reducer,
-    [accountingApi.reducerPath]: accountingApi.reducer,
-    [vestingSubgraphApi.reducerPath]: vestingSubgraphApi.reducer,
-    [autoWrapSubgraphApi.reducerPath]: autoWrapSubgraphApi.reducer,
-    [schedulingSubgraphApi.reducerPath]: schedulingSubgraphApi.reducer,
-    [addressBookRpcApi.reducerPath]: addressBookRpcApi.reducer,
+	reducer: {
+		// API slices
+		[rpcApi.reducerPath]: rpcApi.reducer,
+		[subgraphApi.reducerPath]: subgraphApi.reducer,
+		[transactionTracker.reducerPath]: transactionTrackerPersistedReducer,
+		[efpApi.reducerPath]: efpApi.reducer,
+		[ensApi.reducerPath]: ensApi.reducer,
+		[lensApi.reducerPath]: lensApi.reducer,
+		[gasApi.reducerPath]: gasApi.reducer,
+		[platformApi.reducerPath]: platformApi.reducer,
+		[faucetApi.reducerPath]: faucetApi.reducer,
+		[tokenPriceApi.reducerPath]: tokenPriceApi.reducer,
+		[accountingApi.reducerPath]: accountingApi.reducer,
+		[vestingSubgraphApi.reducerPath]: vestingSubgraphApi.reducer,
+		[autoWrapSubgraphApi.reducerPath]: autoWrapSubgraphApi.reducer,
+		[schedulingSubgraphApi.reducerPath]: schedulingSubgraphApi.reducer,
+		[addressBookRpcApi.reducerPath]: addressBookRpcApi.reducer,
 
-    // Persisted slices
-    appSettings: appSettingsPersistedReducer,
-    impersonations: impersonationPersistedReducer,
-    addressBook: addressBookPersistedReducer,
-    customTokens: customTokensPersistedReducer,
-    networkPreferences: networkPreferencesPersistedReducer,
-    notifications: notificatonsPersistedReducer,
-    flags: flagsPersistedReducer,
+		// Persisted slices
+		appSettings: appSettingsPersistedReducer,
+		impersonations: impersonationPersistedReducer,
+		addressBook: addressBookPersistedReducer,
+		customTokens: customTokensPersistedReducer,
+		networkPreferences: networkPreferencesPersistedReducer,
+		notifications: notificatonsPersistedReducer,
+		flags: flagsPersistedReducer,
 
-    // Default slices
-    pendingUpdates: pendingUpdateSlice.reducer,
-  },
-  enhancers: (existingEnhancers) =>
-    existingEnhancers.concat(
-      autoBatchEnhancer({
-        type: typeof window !== "undefined" ? "raf" : "tick",
-      })
-    ), // https://redux-toolkit.js.org/api/autoBatchEnhancer#autobatchenhancer-1
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: {
-        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER], // Ignore redux-persist actions: https://stackoverflow.com/a/62610422
-      },
-    })
-      .prepend(listenerMiddleware.middleware)
-      .prepend(sentryErrorLogger)
-      .concat(rpcApi.middleware)
-      .concat(vestingSubgraphApi.middleware)
-      .concat(autoWrapSubgraphApi.middleware)
-      .concat(schedulingSubgraphApi.middleware)
-      .concat(subgraphApi.middleware)
-      .concat(ensApi.middleware)
-      .concat(lensApi.middleware)
-      .concat(gasApi.middleware)
-      .concat(platformApi.middleware)
-      .concat(faucetApi.middleware)
-      .concat(tokenPriceApi.middleware)
-      .concat(accountingApi.middleware)
-      .concat(addressBookRpcApi.middleware),
-});
+		// Default slices
+		pendingUpdates: pendingUpdateSlice.reducer,
+	},
+	enhancers: existingEnhancers =>
+		existingEnhancers.concat(
+			autoBatchEnhancer({
+				type: typeof window !== 'undefined' ? 'raf' : 'tick',
+			})
+		), // https://redux-toolkit.js.org/api/autoBatchEnhancer#autobatchenhancer-1
+	middleware: getDefaultMiddleware =>
+		getDefaultMiddleware({
+			serializableCheck: {
+				ignoredActions: [
+					FLUSH,
+					REHYDRATE,
+					PAUSE,
+					PERSIST,
+					PURGE,
+					REGISTER,
+				], // Ignore redux-persist actions: https://stackoverflow.com/a/62610422
+			},
+		})
+			.prepend(listenerMiddleware.middleware)
+			.prepend(sentryErrorLogger)
+			.concat(rpcApi.middleware)
+			.concat(vestingSubgraphApi.middleware)
+			.concat(autoWrapSubgraphApi.middleware)
+			.concat(schedulingSubgraphApi.middleware)
+			.concat(subgraphApi.middleware)
+			.concat(efpApi.middleware)
+			.concat(ensApi.middleware)
+			.concat(lensApi.middleware)
+			.concat(gasApi.middleware)
+			.concat(platformApi.middleware)
+			.concat(faucetApi.middleware)
+			.concat(tokenPriceApi.middleware)
+			.concat(accountingApi.middleware)
+			.concat(addressBookRpcApi.middleware),
+})
 
-export const reduxPersistor = persistStore(reduxStore);
+export const reduxPersistor = persistStore(reduxStore)
 
 // optional, but required for refetchOnFocus/refetchOnReconnect behaviors of RTK-Query
-setupListeners(reduxStore.dispatch);
+setupListeners(reduxStore.dispatch)
 
-export type AppStore = typeof reduxStore;
-export type RootState = ReturnType<AppStore["getState"]>;
-export type AppDispatch = AppStore["dispatch"];
+export type AppStore = typeof reduxStore
+export type RootState = ReturnType<AppStore['getState']>
+export type AppDispatch = AppStore['dispatch']
 
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/pages/address-book.tsx
+++ b/src/pages/address-book.tsx
@@ -51,6 +51,8 @@ import { resolvedWagmiClients } from "../features/wallet/WagmiManager";
 import { efpApi } from "../features/efp/efpApi.slice";
 import { useAccount } from "wagmi";
 import Link from "next/link";
+import AddressBookLoadingRow from "../features/addressBook/AddressBookLoadingRow";
+import AddressBookMobileLoadingRow from "../features/addressBook/AddressBookMobileLoadingRow";
 
 const AddressBook: NextPage = () => {
   const dispatch = useAppDispatch();
@@ -85,6 +87,7 @@ const AddressBook: NextPage = () => {
     limit: rowsPerPage.following,
   });
   const following = followingQuery.data;
+  const isFollowingLoading = followingQuery.isLoading || followingQuery.isFetching;
 
   const incomingStreamsQuery = subgraphApi.useStreamsQuery(
     visibleAddress
@@ -769,7 +772,7 @@ const AddressBook: NextPage = () => {
           </>
         )}
 
-        {filteredFollowing.length === 0 && (
+        {filteredFollowing.length === 0 && !isFollowingLoading && (
           <Paper elevation={1} sx={{ px: 12, py: 7 }} translate="yes">
             <Typography
               data-cy={"no-address-title"}
@@ -788,7 +791,7 @@ const AddressBook: NextPage = () => {
           </Paper>
         )}
 
-        {filteredFollowing.length > 0 && (
+        {(filteredFollowing.length > 0 || isFollowingLoading) && (
           <>
             <Typography
               sx={{ marginBottom: isBelowMd ? -1.5 : -3.5 }}
@@ -824,30 +827,34 @@ const AddressBook: NextPage = () => {
                   </TableHead>
                 )}
                 <TableBody>
-                  {filteredFollowing.map(
-                    ({ address, streams }) =>
-                      isBelowMd ? (
-                        <AddressBookMobileRow
-                          key={address}
-                          address={address}
-                          selected={selectedAddresses.includes(address)}
-                          selectable={false}
-                          onSelect={setRowSelected(address)}
-                        />
-                      ) : (
-                        <AddressBookRow
-                          key={address}
-                          address={address}
-                          selected={selectedAddresses.includes(address)}
-                          selectable={false}
-                          onSelect={setRowSelected(address)}
-                          streams={streams}
-                          streamsLoading={streamsLoading}
-                          chainIds={[1, 10, 8453]}
-                          canEdit={false}
-                        />
-                      )
-                  )}
+                  {isFollowingLoading ?
+                    Array.from({ length: rowsPerPage.following }).map((_, index) => (
+                      isBelowMd ? <AddressBookMobileLoadingRow key={index} /> : <AddressBookLoadingRow key={index} />
+                    ))
+                    : filteredFollowing.map(
+                      ({ address, streams }) =>
+                        isBelowMd ? (
+                          <AddressBookMobileRow
+                            key={address}
+                            address={address}
+                            selected={selectedAddresses.includes(address)}
+                            selectable={false}
+                            onSelect={setRowSelected(address)}
+                          />
+                        ) : (
+                          <AddressBookRow
+                            key={address}
+                            address={address}
+                            selected={selectedAddresses.includes(address)}
+                            selectable={false}
+                            onSelect={setRowSelected(address)}
+                            streams={streams}
+                            streamsLoading={streamsLoading}
+                            chainIds={[1, 10, 8453]}
+                            canEdit={false}
+                          />
+                        )
+                    )}
                 </TableBody>
               </Table>
               <TablePagination

--- a/src/pages/address-book.tsx
+++ b/src/pages/address-book.tsx
@@ -776,15 +776,15 @@ const AddressBook: NextPage = () => {
               variant="h4"
               textAlign="center"
             >
-              You don&apos;t follow anyone yet
+              {accountAddress ? "You don't follow anyone yet" : "Connect your wallet to see your friends"}
             </Typography>
-            <Typography
+            {accountAddress && <Typography
               data-cy={"no-address-message"}
               color="text.secondary"
               textAlign="center"
             >
               Follow people on <Link href="https://efp.app" target="_blank" rel="noopener noreferrer">EFP (Ethereum Follow Protocol)</Link> to see them here.
-            </Typography>
+            </Typography>}
           </Paper>
         )}
 

--- a/src/pages/address-book.tsx
+++ b/src/pages/address-book.tsx
@@ -48,9 +48,9 @@ import { useVisibleAddress } from "../features/wallet/VisibleAddressContext";
 import { LoadingButton } from "@mui/lab";
 import { publicClientToProvider } from "../utils/wagmiEthersAdapters";
 import { resolvedWagmiClients } from "../features/wallet/WagmiManager";
-import { PublicClient } from "viem";
 import { efpApi } from "../features/efp/efpApi.slice";
 import { useAccount } from "wagmi";
+import Link from "next/link";
 
 const AddressBook: NextPage = () => {
   const dispatch = useAppDispatch();
@@ -282,7 +282,7 @@ const AddressBook: NextPage = () => {
       outgoingStreamsQuery.data?.items || []
     );
 
-    return following?.map((entry) => {
+    return following ? following?.map((entry) => {
       return {
         ...entry,
         streams: allStreams.filter((stream) =>
@@ -291,7 +291,7 @@ const AddressBook: NextPage = () => {
           )
         ),
       };
-    });
+    }) : [];
   }, [
     incomingStreamsQuery.data,
     outgoingStreamsQuery.data,
@@ -328,7 +328,7 @@ const AddressBook: NextPage = () => {
   const filteredFollowing = useMemo(
     () =>
       mappedFollowing
-        ?.filter(
+        .filter(
           (entry) =>
             addressesFilter.length === 0 ||
             addressesFilter.includes(entry.address)
@@ -769,7 +769,26 @@ const AddressBook: NextPage = () => {
           </>
         )}
 
-        {filteredFollowing && filteredFollowing.length > 0 && (
+        {filteredFollowing.length === 0 && (
+          <Paper elevation={1} sx={{ px: 12, py: 7 }} translate="yes">
+            <Typography
+              data-cy={"no-address-title"}
+              variant="h4"
+              textAlign="center"
+            >
+              You don&apos;t follow anyone yet
+            </Typography>
+            <Typography
+              data-cy={"no-address-message"}
+              color="text.secondary"
+              textAlign="center"
+            >
+              Follow people on <Link href="https://efp.app" target="_blank" rel="noopener noreferrer">EFP (Ethereum Follow Protocol)</Link> to see them here.
+            </Typography>
+          </Paper>
+        )}
+
+        {filteredFollowing.length > 0 && (
           <>
             <Typography
               sx={{ marginBottom: isBelowMd ? -1.5 : -3.5 }}

--- a/src/pages/address-book.tsx
+++ b/src/pages/address-book.tsx
@@ -430,6 +430,20 @@ const AddressBook: NextPage = () => {
   const streamsLoading =
     incomingStreamsQuery.isLoading || outgoingStreamsQuery.isLoading;
 
+  const onStarAddress = (address: Address) => {
+    if (addressBookEntries.some((entry) => entry.address.toLowerCase() === address.toLowerCase())) {
+      dispatch(
+        removeAddressBookEntries(
+          filteredEntries
+            .filter((entry) => entry.address.toLowerCase() === address.toLowerCase())
+            .map(adapter.selectId)
+        )
+      );
+    } else {
+      onAddAddress({ address, name: "", associatedNetworks: [1, 10, 8453], isContract: false });
+    }
+  };
+
   return (
     <Container maxWidth="lg">
       <AddressSearchDialog
@@ -840,6 +854,8 @@ const AddressBook: NextPage = () => {
                             selected={selectedAddresses.includes(address)}
                             selectable={false}
                             onSelect={setRowSelected(address)}
+                            isStarred={addressBookEntries.some((entry) => entry.address.toLowerCase() === address.toLowerCase())}
+                            onStarClick={() => onStarAddress(address)}
                           />
                         ) : (
                           <AddressBookRow
@@ -852,6 +868,8 @@ const AddressBook: NextPage = () => {
                             streamsLoading={streamsLoading}
                             chainIds={[1, 10, 8453]}
                             canEdit={false}
+                            isStarred={addressBookEntries.some((entry) => entry.address.toLowerCase() === address.toLowerCase())}
+                            onStarClick={() => onStarAddress(address)}
                           />
                         )
                     )}


### PR DESCRIPTION
This is a PR realted to the issue https://github.com/superfluid-org/superfluid-dashboard/issues/787 to add the Ethereum Follow Protocol data to the Address Book as a separate table.

This PR introduces:
- efpApi slice for fetching user#s Followings (paginated) and stats
- populating a new table with the data from the efp api
- empty table that links to EFP so they can start following people to then get displayed in Superfluid address book