### PR TITLE
fix: exclude testnets from Li.Fi widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "38.0.0",
+  "version": "39.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/bridge/LiFiWidgetManager.tsx
+++ b/src/features/bridge/LiFiWidgetManager.tsx
@@ -20,7 +20,7 @@ const LiFiWidget = dynamic(() => import('@lifi/widget').then(mod => mod.LiFiWidg
 export function LiFiWidgetManager() {
     const theme = useTheme();
     const { isEOA } = useVisibleAddress();
-    const { availableNetworks } = useAvailableNetworks();
+    const { availableMainNetworks } = useAvailableNetworks();
 
     const { openConnectModal } = useConnectButton();
 
@@ -56,7 +56,7 @@ export function LiFiWidgetManager() {
             appearance: theme.palette.mode,
             theme: widgetTheme,
             chains: {
-                allow: availableNetworks.map(x => x.id)
+                allow: availableMainNetworks.map(x => x.id)
             },
             requiredUI: isEOA ? [] : ["toAddress"],
             hiddenUI: ["appearance"],
@@ -71,7 +71,7 @@ export function LiFiWidgetManager() {
         } as Partial<WidgetConfig>;
 
         return config;
-    }, [isEOA, availableNetworks, theme, openConnectModal, featuredTokens]);
+    }, [isEOA, availableMainNetworks, theme, openConnectModal, featuredTokens]);
 
     // # Side
     const { stopAutoSwitchToWalletNetwork } = useExpectedNetwork();


### PR DESCRIPTION
## Summary
- Exclude testnet networks from Li.Fi widget trading paths by using `availableMainNetworks` instead of `availableNetworks`
- Bump version to 39.0.0

## Test plan
- [x] Open the bridge page and verify no testnet chains appear in the chain selector
- [x] Confirm mainnet chains still work correctly for swaps/bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)