### PR TITLE
chore: disable Segment and HotJar tracking initialization

### DIFF
--- a/src/features/analytics/AnalyticsProvider.tsx
+++ b/src/features/analytics/AnalyticsProvider.tsx
@@ -17,7 +17,7 @@ export const AnalyticsContext = createContext<AnalyticsContextValue>(undefined!)
 
 const useAnalyticsBrowser = () =>
   useMemo(() => {
-    const writeKey = config.segmentWriteKey;
+    const writeKey: string | undefined = undefined; // Tracking disabled: force no-op Segment instance.
     if (!IsCypress && writeKey) {
       return AnalyticsBrowser.load(
         { writeKey },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -55,12 +55,8 @@ export default function MyApp(props: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page);
 
   useEffect(() => {
-    const { id, sv } = config.hotjar;
-    if (!IsCypress && id && sv) {
-      hotjar.initialize({ id: Number(id), sv: Number(sv) });
-    } else {
-      console.warn("Hotjar not initialized.");
-    }
+    // Tracking disabled: Hotjar initialization intentionally skipped.
+    console.warn("Hotjar not initialized.");
   }, []);
 
   const [mounted, setMounted] = useState(false);


### PR DESCRIPTION
## Summary

Stops analytics tracking in the dashboard by disabling initialization of Segment and HotJar. Consumer call sites are left intact and become silent no-ops — no further tracking data leaves the app.

- `src/features/analytics/AnalyticsProvider.tsx` — forces `writeKey` to `undefined` so `AnalyticsBrowser` loads via the existing `"NOOP"` fallback branch. All `track()` / `identify()` / `page()` / `txAnalytics()` call sites (e.g. in `MonitorContext.tsx` and transaction buttons) keep working as no-ops.
- `src/pages/_app.tsx` — removes the `hotjar.initialize()` call from the `useEffect`. The existing `hotjar.initialized()` guards in `MonitorContext.tsx` ensure consumer `hotjar.identify()` calls become safe no-ops automatically.

No consumers were modified. `react-hotjar`, `@segment/analytics-next`, and the env-var/config plumbing in `utils/config.ts` are kept as-is so the change can be reversed with a one-line edit at each init site.

Matomo was also requested — it is not present in this codebase, so no action was needed there.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm dev` — DevTools Network tab shows no requests to `static.hotjar.com` / `script.hotjar.com`, and only the harmless 404 metadata fetch to `cdn.segment.com/v1/projects/NOOP/settings` (no user data)
- [ ] Console shows `"Segment not initialized. No-op instance provided instead."` and `"Hotjar not initialized."`
- [ ] Navigating the app, connecting/disconnecting a wallet, and starting a transaction produce no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)