### PR TITLE
feat: switch token balance chart to balances API

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -111,6 +111,10 @@ const nextConfig: NextConfig = {
       source: "/monitoring",
       destination: "/api/monitoring",
     },
+    {
+      source: "/balance-api/:path*",
+      destination: `${process.env.BALANCE_API_REWRITE_TARGET || "https://balances.superfluid.dev"}/:path*`,
+    },
   ],
   env: {
     NEXT_PUBLIC_APP_URL: appUrl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "39.0.0",
+  "version": "40.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/balance/balanceApi.slice.ts
+++ b/src/features/balance/balanceApi.slice.ts
@@ -1,0 +1,91 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { Address } from "@superfluid-finance/sdk-core";
+import config from "../../utils/config";
+import { allNetworks, findNetworkOrThrow, Network } from "../network/networks";
+
+export interface BalanceHistoryPoint {
+  timestamp: string;
+  connectedBalance: string;
+  disconnectedBalance: string;
+  deposit: string;
+  totalBalance: string;
+}
+
+export interface BalanceHistoryResponse {
+  points: BalanceHistoryPoint[];
+}
+
+interface BalanceHistoryArgs {
+  chainId: number;
+  account: Address;
+  token: Address;
+  startTimestamp: number;
+  endTimestamp?: number;
+  points?: number;
+}
+
+interface FirstMovementArgs {
+  chainId: number;
+  account: Address;
+  token: Address;
+}
+
+interface MovementsResponse {
+  movements: Array<{ timestamp: string }>;
+  total: number;
+  totalIsCapped: boolean;
+  hasMore: boolean;
+}
+
+const getSuperfluidCanonicalSlug = (network: Network): string => {
+  const url = network.rpcUrls.superfluid?.http?.[0];
+  if (!url) {
+    throw new Error(`No Superfluid RPC URL for chain ${network.id}`);
+  }
+  return new URL(url).pathname.replace(/^\/+/, "");
+};
+
+const balanceApi = createApi({
+  reducerPath: "balance",
+  baseQuery: fetchBaseQuery({
+    baseUrl: config.balanceApi,
+    timeout: 15_000,
+  }),
+  endpoints: (builder) => ({
+    firstMovementTimestamp: builder.query<number | null, FirstMovementArgs>({
+      query: ({ chainId, account, token }) => {
+        const network = findNetworkOrThrow(allNetworks, chainId);
+        return {
+          url: `/v1/accounts/${account.toLowerCase()}/tokens/${token.toLowerCase()}/movements`,
+          params: {
+            chain: getSuperfluidCanonicalSlug(network),
+            sort: "asc",
+            limit: "1",
+          },
+        };
+      },
+      transformResponse: (response: MovementsResponse) => {
+        const first = response.movements[0];
+        return first ? Number(first.timestamp) : null;
+      },
+    }),
+    balanceHistory: builder.query<BalanceHistoryResponse, BalanceHistoryArgs>({
+      query: ({ chainId, account, token, startTimestamp, endTimestamp, points }) => {
+        const network = findNetworkOrThrow(allNetworks, chainId);
+        const chain = getSuperfluidCanonicalSlug(network);
+        const params: Record<string, string> = {
+          chain,
+          startTimestamp: startTimestamp.toString(),
+        };
+        if (endTimestamp !== undefined) params.endTimestamp = endTimestamp.toString();
+        if (points !== undefined) params.points = points.toString();
+        return {
+          url: `/v1/accounts/${account.toLowerCase()}/tokens/${token.toLowerCase()}/balance-snapshots`,
+          params,
+        };
+      },
+    }),
+  }),
+});
+
+export default balanceApi;

--- a/src/features/redux/store.ts
+++ b/src/features/redux/store.ts
@@ -38,6 +38,7 @@ import { deserializeError } from "serialize-error";
 import { schedulingSubgraphApi } from "../../scheduling-subgraph/schedulingSubgraphApi";
 import { vestingSubgraphApi } from "../../vesting-subgraph/vestingSubgraphApi";
 import accountingApi from "../accounting/accountingApi.slice";
+import balanceApi from "../balance/balanceApi.slice";
 import { addressBookSlice, AddressBookState } from "../addressBook/addressBook.slice";
 import { customTokensSlice, getCustomTokenId, NetworkCustomTokenState } from "../customTokens/customTokens.slice";
 import { efpApi } from "../efp/efpApi.slice";
@@ -269,6 +270,7 @@ export const reduxStore = configureStore({
     [faucetApi.reducerPath]: faucetApi.reducer,
     [tokenPriceApi.reducerPath]: tokenPriceApi.reducer,
     [accountingApi.reducerPath]: accountingApi.reducer,
+    [balanceApi.reducerPath]: balanceApi.reducer,
     [vestingSubgraphApi.reducerPath]: vestingSubgraphApi.reducer,
     [autoWrapSubgraphApi.reducerPath]: autoWrapSubgraphApi.reducer,
     [schedulingSubgraphApi.reducerPath]: schedulingSubgraphApi.reducer,
@@ -306,6 +308,7 @@ export const reduxStore = configureStore({
     .concat(faucetApi.middleware)
     .concat(tokenPriceApi.middleware)
     .concat(accountingApi.middleware)
+    .concat(balanceApi.middleware)
     .concat(addressBookRpcApi.middleware),
   enhancers: (getDefaultEnhancers) =>
     getDefaultEnhancers({

--- a/src/features/token/TokenGraph/TokenBalanceGraph.tsx
+++ b/src/features/token/TokenGraph/TokenBalanceGraph.tsx
@@ -1,102 +1,86 @@
-import { Skeleton, useTheme } from "@mui/material";
+import { Button, Skeleton, Stack, Typography, useTheme } from "@mui/material";
 import { Address } from "@superfluid-finance/sdk-core";
 import { ChartOptions } from "chart.js/auto";
-import { fromUnixTime, getUnixTime, isSameDay, max, sub } from "date-fns";
+import { fromUnixTime, getUnixTime, sub } from "date-fns";
 import { BigNumber, ethers } from "ethers";
-import minBy from "lodash/fp/minBy";
 import { FC, useMemo } from "react";
 import LineChart, { DataPoint } from "../../../components/Chart/LineChart";
 import {
   buildDefaultDatasetConf,
-  estimateFrequencyByTimestamp,
   getFilteredStartDate,
 } from "../../../utils/chartUtils";
-import { dateNowSeconds, getDatesBetween } from "../../../utils/dateUtils";
+import balanceApi from "../../balance/balanceApi.slice";
 import { TimeUnitFilterType } from "../../graph/TimeUnitFilter";
 import { Network } from "../../network/networks";
-import { TokenBalance } from "../../redux/endpoints/adHocSubgraphEndpoints";
 import { RealtimeBalance } from "../../redux/endpoints/balanceFetcher";
-import { rpcApi, subgraphApi } from "../../redux/store";
+import { rpcApi } from "../../redux/store";
+
+// Fallback floor used only when the "All" filter is selected AND the
+// account has no recorded movements yet (so the history request has no
+// meaningful start anyway). 2021-01-01 UTC predates Superfluid mainnet
+// deployment on every supported chain.
+const ALL_FALLBACK_FLOOR_UNIX = 1_609_459_200;
+const FORECAST_POINTS = 12;
+const FORECAST_MAX_DURATION_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+const projectBalanceAt = (
+  realTimeBalance: RealtimeBalance,
+  date: Date
+): DataPoint => {
+  const { balance, balanceTimestamp, flowRate } = realTimeBalance;
+  const elapsed = BigNumber.from(getUnixTime(date) - balanceTimestamp);
+  const projected = BigNumber.from(balance).add(
+    BigNumber.from(flowRate).mul(elapsed)
+  );
+  const clamped = projected.gt(0) ? projected : BigNumber.from(0);
+  const ether = ethers.utils.formatEther(clamped);
+  return { x: date.getTime(), y: Number(ether), ether };
+};
 
 const mapForecastDatesWithData = (
   realTimeBalance: RealtimeBalance,
   dates: Date[]
-) => {
-  const {
-    balance,
-    balanceTimestamp: balanceTimestamp,
-    flowRate,
-  } = realTimeBalance;
+): DataPoint[] => {
+  const { balance, balanceTimestamp, flowRate } = realTimeBalance;
+  const balanceBN = BigNumber.from(balance);
+  const flowRateBN = BigNumber.from(flowRate);
 
-  const balanceBigNumber = BigNumber.from(balance);
+  const points: DataPoint[] = [];
 
-  return dates.map((date) => {
-    const etherAtDate = ethers.utils.formatEther(
-      balanceBigNumber.add(
-        BigNumber.from(flowRate).mul(
-          BigNumber.from(getUnixTime(date) - balanceTimestamp)
-        )
-      )
-    );
+  for (const date of dates) {
+    const elapsed = BigNumber.from(getUnixTime(date) - balanceTimestamp);
+    const projected = balanceBN.add(flowRateBN.mul(elapsed));
 
-    return {
-      x: date.getTime(),
-      y: Number(etherAtDate),
-      ether: etherAtDate,
-    };
-  });
+    if (projected.lte(0) && flowRateBN.lt(0)) {
+      // Zero-crossing: emit an exact zero point at the crossing time, then
+      // stop the forecast line.
+      const zeroCrossingUnix =
+        balanceTimestamp +
+        Number(balanceBN.mul(BigNumber.from(-1)).div(flowRateBN));
+      points.push({
+        x: zeroCrossingUnix * 1000,
+        y: 0,
+        ether: "0.0",
+      });
+      break;
+    }
+
+    points.push(projectBalanceAt(realTimeBalance, date));
+  }
+
+  return points;
 };
 
-const mapDatesWithData = (
-  tokenBalances: Array<TokenBalance>,
-  dates: Array<Date>
-): DataPoint[] =>
-  dates.reduce<{
-    data: DataPoint[];
-    lastTokenBalance: TokenBalance;
-  }>(
-    ({ data, lastTokenBalance }, date) => {
-      const currentTokenBalance =
-        tokenBalances.find(({ timestamp }) =>
-          isSameDay(date, new Date(timestamp * 1000))
-        ) || lastTokenBalance;
-
-      const { balance, totalNetFlowRate, timestamp } = currentTokenBalance;
-
-      const flowingBalance =
-        totalNetFlowRate !== "0"
-          ? BigNumber.from(totalNetFlowRate).mul(
-            BigNumber.from(Math.floor(date.getTime() / 1000) - timestamp)
-          )
-          : BigNumber.from(0);
-
-      const wei = BigNumber.from(balance).add(flowingBalance);
-
-      const pointValue = ethers.utils.formatEther(
-        wei.gt(BigNumber.from(0)) ? wei : BigNumber.from(0)
-      );
-
-      return {
-        data: [
-          ...data,
-          {
-            x: date.getTime(),
-            y: Number(pointValue),
-            ether: pointValue,
-          },
-        ],
-        lastTokenBalance: currentTokenBalance,
-      };
-    },
-    {
-      data: [],
-      lastTokenBalance: {
-        balance: "0",
-        totalNetFlowRate: "0",
-        timestamp: dateNowSeconds(),
-      } as TokenBalance,
-    }
-  ).data;
+const getDatesBetween = (start: Date, end: Date, steps: number): Date[] => {
+  if (steps <= 0 || end.getTime() <= start.getTime()) return [];
+  const startMs = start.getTime();
+  const span = end.getTime() - startMs;
+  const out: Date[] = [];
+  for (let i = 0; i <= steps; i++) {
+    out.push(new Date(startMs + (span * i) / steps));
+  }
+  return out;
+};
 
 interface TokenBalanceGraphProps {
   filter: TimeUnitFilterType;
@@ -117,110 +101,186 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
 }) => {
   const theme = useTheme();
 
+  const isAll = filter === TimeUnitFilterType.All;
+
+  // For "All", look up the timestamp of the account's first recorded
+  // movement for this token. Use that as the chart start so the X range
+  // isn't padded with a long flat-zero stretch.
+  const firstMovementQuery = balanceApi.useFirstMovementTimestampQuery(
+    { chainId: network.id, account, token },
+    { skip: !isAll }
+  );
+
+  const { startTimestamp, dateNow, forecastEndDate } = useMemo(() => {
+    const currentDate = new Date();
+    const currentUnix = getUnixTime(currentDate);
+
+    let startUnix: number;
+    if (isAll) {
+      if (firstMovementQuery.isLoading || firstMovementQuery.isError) {
+        // Probe pending or failed — pick a sensible recent window so we
+        // don't fire the history request with the 2021 floor (which wastes
+        // points). On success the history query re-fires with the real
+        // first-movement timestamp.
+        startUnix = getUnixTime(sub(currentDate, { months: 1 }));
+      } else {
+        const firstMovementUnix = firstMovementQuery.data ?? null;
+        startUnix = firstMovementUnix ?? ALL_FALLBACK_FLOOR_UNIX;
+      }
+    } else {
+      const startDate = getFilteredStartDate(
+        filter,
+        currentDate,
+        currentDate // non-All filters never hit the default
+      );
+      startUnix = getUnixTime(startDate);
+    }
+
+    const proportionalDurationUnix = Math.floor((currentUnix - startUnix) / 4);
+    const forecastDurationUnix = Math.min(
+      proportionalDurationUnix,
+      FORECAST_MAX_DURATION_SECONDS
+    );
+    const forecastEndUnix = currentUnix + forecastDurationUnix;
+    return {
+      startTimestamp: startUnix,
+      dateNow: currentDate,
+      forecastEndDate: fromUnixTime(forecastEndUnix),
+    };
+  }, [
+    filter,
+    isAll,
+    firstMovementQuery.data,
+    firstMovementQuery.isLoading,
+    firstMovementQuery.isError,
+  ]);
+
+  const balanceHistoryQuery = balanceApi.useBalanceHistoryQuery(
+    {
+      chainId: network.id,
+      account,
+      token,
+      startTimestamp,
+      points: 50,
+    },
+    // Wait for the "All" probe to resolve before firing — avoids a
+    // throwaway request against a stale default window.
+    { skip: isAll && firstMovementQuery.isLoading }
+  );
+
   const realTimeBalanceQuery = rpcApi.useRealtimeBalanceQuery({
     chainId: network.id,
     tokenAddress: token,
     accountAddress: account,
   });
 
-  const accountTokenBalanceHistoryQuery =
-    subgraphApi.useAccountTokenBalanceHistoryQuery({
-      chainId: network.id,
-      accountAddress: account,
-      tokenAddress: token,
+  useMemo(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (balanceHistoryQuery.isError) {
+      // eslint-disable-next-line no-console
+      console.error(
+        "[TokenBalanceGraph] balance-history request failed",
+        balanceHistoryQuery.error
+      );
+    } else if (balanceHistoryQuery.data) {
+      const pts = balanceHistoryQuery.data.points;
+      // eslint-disable-next-line no-console
+      console.debug(
+        "[TokenBalanceGraph] balance-history points=%d first=%o last=%o",
+        pts.length,
+        pts[0],
+        pts[pts.length - 1]
+      );
+    }
+  }, [
+    balanceHistoryQuery.data,
+    balanceHistoryQuery.error,
+    balanceHistoryQuery.isError,
+  ]);
+
+  const datasets = useMemo<DataPoint[][]>(() => {
+    const points = balanceHistoryQuery.data?.points ?? [];
+
+    const balanceDataset: DataPoint[] = points.map((p) => {
+      const wei = BigNumber.from(p.connectedBalance);
+      const ether = ethers.utils.formatEther(
+        wei.gt(BigNumber.from(0)) ? wei : BigNumber.from(0)
+      );
+      return {
+        x: Number(p.timestamp) * 1000,
+        y: Number(ether),
+        ether,
+      };
     });
 
-  const tokenBalances = useMemo(
-    () => accountTokenBalanceHistoryQuery.data || [],
-    [accountTokenBalanceHistoryQuery.data]
-  );
+    // Replace the API's tail point with the RPC live value. The API
+    // emits 50 evenly-spaced points up to ~now, but its last point can
+    // be indexer-lagged (today's value is still yesterday's). Using
+    // RPC for the right edge guarantees the chart shows the actual
+    // current balance and connects cleanly to the forecast (also RPC).
+    if (realTimeBalanceQuery.data && balanceDataset.length > 0) {
+      const livePoint = projectBalanceAt(realTimeBalanceQuery.data, dateNow);
+      if (livePoint.x > balanceDataset[balanceDataset.length - 1].x) {
+        balanceDataset.pop();
+      }
+      balanceDataset.push(livePoint);
+    }
 
-  const { startDate, endDate, dateNow, frequency } = useMemo(() => {
-    const currentDate = new Date();
-    const currentDateUnix = getUnixTime(currentDate);
+    if (!showForecast || !realTimeBalanceQuery.data) {
+      return [balanceDataset, []];
+    }
 
-    const smallestTimestamp =
-      minBy((x) => x.timestamp, tokenBalances)?.timestamp || currentDateUnix;
-
-    const minimumDateUnix = getUnixTime(sub(currentDate, { days: 1 }));
-
-    const startDateUnix = Math.min(smallestTimestamp, minimumDateUnix);
-
-    const forecastEndUnix =
-      currentDateUnix + (currentDateUnix - startDateUnix) / 4;
-
-    const endDateUnix = showForecast ? forecastEndUnix : currentDateUnix;
-
-    const frequency = estimateFrequencyByTimestamp(
-      startDateUnix,
-      currentDateUnix
+    const forecastDates = getDatesBetween(
+      dateNow,
+      forecastEndDate,
+      FORECAST_POINTS
+    );
+    const forecastDataset = mapForecastDatesWithData(
+      realTimeBalanceQuery.data,
+      forecastDates
     );
 
-    return {
-      dateNow: currentDate,
-      startDate: fromUnixTime(startDateUnix - frequency),
-      endDate: fromUnixTime(endDateUnix),
-      frequency,
-    };
-  }, [tokenBalances, showForecast]);
+    return [balanceDataset, forecastDataset];
+  }, [
+    balanceHistoryQuery.data,
+    realTimeBalanceQuery.data,
+    showForecast,
+    dateNow,
+    forecastEndDate,
+  ]);
 
-  const datasets = useMemo(
-    () => {
-      if (tokenBalances.length === 0) return [[], []];
+  const options = useMemo<ChartOptions<"line">>(() => {
+    // Derive the X-axis bounds from the rendered data so datasets and
+    // bounds always mutate atomically in the same React commit. During
+    // a refetch (e.g. filter switch) the chart keeps showing the
+    // previous response's points against their own coherent range,
+    // then everything swaps in one commit when the new response lands.
+    const balanceDataset = datasets[0];
+    const forecastDataset = datasets[1];
 
-      const balanceDates = getDatesBetween(startDate, dateNow, frequency);
+    if (balanceDataset.length === 0) {
+      return {
+        scales: {
+          x: { offset: true },
+          y: { offset: true },
+        },
+      };
+    }
 
-      const balanceDataset = mapDatesWithData(tokenBalances, balanceDates);
-
-      if (!showForecast || !realTimeBalanceQuery.data)
-        return [balanceDataset, []];
-
-      const forecastDates = getDatesBetween(dateNow, endDate, frequency);
-      const forecastDataset = mapForecastDatesWithData(
-        realTimeBalanceQuery.data,
-        forecastDates
-      );
-
-      return [balanceDataset, forecastDataset];
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      tokenBalances,
-      realTimeBalanceQuery.data,
-      showForecast,
-      startDate,
-      endDate,
-      dateNow,
-      frequency,
-    ]
-  );
-
-  const options = useMemo(() => {
-    const startDateWithMinimum = max([
-      startDate,
-      getFilteredStartDate(filter, dateNow, startDate),
-    ]);
-
-    const dateNowUnix = getUnixTime(dateNow);
-    const maxDate = showForecast
-      ? fromUnixTime(
-        dateNowUnix + (dateNowUnix - getUnixTime(startDateWithMinimum)) / 4
-      )
-      : dateNow;
+    const firstX = balanceDataset[0].x;
+    const lastHistoricalX = balanceDataset[balanceDataset.length - 1].x;
+    const lastForecastX =
+      forecastDataset.length > 0
+        ? forecastDataset[forecastDataset.length - 1].x
+        : lastHistoricalX;
 
     return {
       scales: {
-        x: {
-          min: startDateWithMinimum.getTime(),
-          max: maxDate.getTime(),
-          offset: true,
-        },
-        y: {
-          offset: true,
-        },
+        x: { min: firstX, max: lastForecastX, offset: true },
+        y: { offset: true },
       },
-    } as ChartOptions<"line">;
-  }, [startDate, dateNow, filter, showForecast]);
+    };
+  }, [datasets]);
 
   const datasetsConfigCallbacks = useMemo(
     () => [
@@ -234,8 +294,18 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     [height, theme.palette.primary.main, theme.palette.secondary.main]
   );
 
-  if (accountTokenBalanceHistoryQuery.isLoading) {
+  if (balanceHistoryQuery.isLoading || firstMovementQuery.isLoading) {
     return <Skeleton variant="rounded" width="100%" height={`${height}px`} />;
+  }
+
+  if (balanceHistoryQuery.isError && !balanceHistoryQuery.data) {
+    return (
+      <BalanceGraphErrorFallback
+        height={height}
+        onRetry={() => balanceHistoryQuery.refetch()}
+        isRetrying={balanceHistoryQuery.isFetching}
+      />
+    );
   }
 
   return (
@@ -247,5 +317,37 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     />
   );
 };
+
+const BalanceGraphErrorFallback: FC<{
+  height: number;
+  onRetry: () => void;
+  isRetrying: boolean;
+}> = ({ height, onRetry, isRetrying }) => (
+  <Stack
+    alignItems="center"
+    justifyContent="center"
+    spacing={1}
+    sx={{
+      height: `${height}px`,
+      width: "100%",
+      borderRadius: 1,
+      border: (theme) => `1px dashed ${theme.palette.divider}`,
+      px: 2,
+      textAlign: "center",
+    }}
+  >
+    <Typography variant="body2" color="text.secondary">
+      Couldn&apos;t load balance history.
+    </Typography>
+    <Button
+      size="small"
+      variant="text"
+      onClick={onRetry}
+      disabled={isRetrying}
+    >
+      {isRetrying ? "Retrying…" : "Try again"}
+    </Button>
+  </Stack>
+);
 
 export default TokenBalanceGraph;

--- a/src/pages/token/[_network]/[_token].tsx
+++ b/src/pages/token/[_network]/[_token].tsx
@@ -140,8 +140,11 @@ const TokenPageContent: FC<{
   const isBelowMd = useMediaQuery(theme.breakpoints.down("md"));
 
   const [activeTab, setActiveTab] = useState(TokenDetailsTabs.Streams);
-  const [graphFilter, setGraphFilter] = useState(TimeUnitFilterType.All);
-  const [showForecast, setShowForecast] = useState(true);
+  const [graphFilter, setGraphFilter] = useState(TimeUnitFilterType.Week);
+  // null = follow data (default off when flow rate is zero); boolean = user override.
+  const [showForecastOverride, setShowForecastOverride] = useState<
+    boolean | null
+  >(null);
   const navigateBack = useNavigateBack();
 
   const tokenPrice = useTokenPrice(network.id, tokenAddress);
@@ -165,8 +168,13 @@ const TokenPageContent: FC<{
     refetchOnFocus: true, // Re-fetch list view more often where there might be something incoming.
   });
 
+  const hasOngoingFlow = realTimeBalanceQuery.data
+    ? !BigNumber.from(realTimeBalanceQuery.data.flowRate).isZero()
+    : false;
+  const showForecast = showForecastOverride ?? hasOngoingFlow;
+
   const onShowForecastChange = (_e: unknown, checked: boolean) =>
-    setShowForecast(checked);
+    setShowForecastOverride(checked);
 
   const onTabChange = (_e: unknown, newTab: TokenDetailsTabs) =>
     setActiveTab(newTab);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -40,6 +40,12 @@ const config = {
   accountingApi:
     process.env.NEXT_PUBLIC_ACCOUNTING_API ||
     "https://accounting.superfluid.dev/v1",
+  // Defaults to a same-origin rewrite (see next.config.ts) so browser calls
+  // stay same-origin. The rewrite forwards to BALANCE_API_REWRITE_TARGET
+  // (default https://balances.superfluid.dev) at the Next.js layer.
+  balanceApi:
+    process.env.NEXT_PUBLIC_BALANCE_API ||
+    "/balance-api",
   segmentWriteKey: isProduction
     ? segmentWriteKeyForProduction
     : isDeployPreview


### PR DESCRIPTION
## Summary
- add a dedicated RTK Query slice for the balances API and wire it into the Redux store
- switch the token balance graph from subgraph snapshot interpolation to balance-history data from the balances API
- route browser requests through the Next.js `/balance-api` rewrite, defaulting to `https://balances.superfluid.dev`
- use the first recorded movement for the `All` filter and keep the existing forecast visualization path

## Testing
- pnpm typecheck
- pnpm lint