### PR TITLE
fix: fall back to wagmi address when AppKit address is unavailable (#819)

### DIFF
--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -6,8 +6,8 @@ import { useAccount as useWagmiAccount } from "wagmi"
 
 // Re-done wagmi's "useAccount" with Reown AppKit instead
 export function useAccount() {
-    const { address, isConnected, status } = useAppKitAccount()
-    const { connector, chain } = useWagmiAccount()
+    const { address: appKitAddress, isConnected, status } = useAppKitAccount()
+    const { connector, chain, address: wagmiAddress } = useWagmiAccount()
 
     const isConnecting = status === "connecting"
     const isReconnecting = status === "reconnecting"
@@ -22,6 +22,12 @@ export function useAccount() {
             return undefined
         }
 
+        // AppKit can lag behind wagmi during reconnection (e.g. page refresh with
+        // existing session). Fall back to wagmi's address so that the transaction
+        // drawer - which filters by signerAddress stored via the wagmi connector -
+        // stays in sync and never shows an empty list while AppKit catches up.
+        const address = appKitAddress ?? wagmiAddress
+
         if (address === zeroAddress) {
             return undefined
         }
@@ -32,7 +38,7 @@ export function useAccount() {
         }
 
         return undefined
-    }, [address, mounted])
+    }, [appKitAddress, wagmiAddress, mounted])
 
     return {
         address: addressLowercased,


### PR DESCRIPTION
## Problem

`useAccount` hook returns `address` exclusively from `useAppKitAccount()`. AppKit can lag behind wagmi during reconnection - for example on a hard page refresh with an existing wallet session, wagmi restores the connection immediately while AppKit goes through its `reconnecting` state with `address = undefined`.

During this window `useAccountTransactions` filters against `undefined` and returns `[]`, so the transaction drawer appears empty until AppKit fully catches up.

## Root cause

`useAccountTransactions` depends on `accountAddress` being defined:

```ts
accountAddress
  ? allTransactions.filter(x => x?.signerAddress?.toLowerCase() === accountAddress.toLowerCase())
  : [] // <- empty when AppKit hasn't resolved yet
```

`signerAddress` stored by `sdk-redux` comes from the wagmi connector client (via `useEthersSigner` -> `useConnectorClient`). Using the same wagmi source as a fallback keeps the comparison consistent.

## Fix

Read `address` from both AppKit and wagmi, prefer AppKit, fall back to wagmi:

```ts
const { address: appKitAddress, ... } = useAppKitAccount()
const { connector, chain, address: wagmiAddress } = useWagmiAccount()

const address = appKitAddress ?? wagmiAddress
```

No change to behavior when AppKit's address is available (the normal connected state). The fallback only activates during the reconnection window.

## Testing

Reproduced locally by adding an artificial 5s delay to `setMounted` to simulate AppKit lag - transaction drawer stays empty for 5s after page load, then populates. With the fix applied the drawer populates immediately on mount since wagmi's address is already available.

Closes #819