### PR TITLE
feat: add base:app_id meta tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "39.0.0",
+  "version": "40.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -28,6 +28,8 @@ export default function MyDocument({ emotionStyleTags }: MyDocumentProps) {
         <link rel="apple-touch-icon" href="/icon-120.png" />
         <meta name="apple-mobile-web-app-title" content="Superfluid" />
 
+        <meta name="base:app_id" content="6a0ed448cc2f5ce0182c4687" />
+
         {/* Inject MUI styles first to match with the prepend: true configuration. */}
         <meta name="emotion-insertion-point" content="" />
         {emotionStyleTags}


### PR DESCRIPTION
## Summary
- Add `<meta name="base:app_id" content="6a0ed448cc2f5ce0182c4687" />` to `_document.tsx` so it's rendered globally on every page.
- Bump major version: `39.0.0` → `40.0.0`.

## Test plan
- [x] `pnpm dev` and confirm `<meta name="base:app_id" content="6a0ed448cc2f5ce0182c4687">` appears in the document `<head>` on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)