### PR TITLE
feat: token balance chart enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "41.0.0",
+  "version": "42.0.0",
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --port 3000",
+    "dev": "next dev --webpack --port 3000",
     "replayio": "replayio record http://localhost:3000",
     "build": "next build --webpack",
     "start": "next start",

--- a/src/components/Chart/LineChart.tsx
+++ b/src/components/Chart/LineChart.tsx
@@ -1,6 +1,11 @@
 import { useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
-import Chart, { ChartDataset, ChartOptions, TooltipItem } from "chart.js/auto";
+import Chart, {
+  ChartDataset,
+  ChartOptions,
+  Plugin,
+  TooltipItem,
+} from "chart.js/auto";
 import { format } from "date-fns";
 import merge from "lodash/fp/merge";
 import set from "lodash/fp/set";
@@ -12,24 +17,73 @@ export interface DataPoint {
   x: number;
   y: number;
   ether: string;
+  // Optional pre-formatted (ether) breakdown surfaced in the tooltip. Only the
+  // historical balance series populates these; forecast/live points leave them
+  // undefined so the tooltip can omit unavailable rows.
+  connected?: string;
+  disconnected?: string;
+  deposit?: string;
+  total?: string;
+  // Set only on the forecast's exact zero-crossing point (genuine projected
+  // liquidation), so it can be distinguished from balances merely clamped to 0.
+  isLiquidation?: boolean;
+  // Set on claimable points where the disconnected balance is the dominant share
+  // of total — used to gradient-fill only those segments of the claimable line.
+  claimableDominant?: boolean;
 }
 
 type DatasetConfigCallback = (
   ctx: CanvasRenderingContext2D
 ) => Omit<ChartDataset<"line">, "data">;
 
+const DEFAULT_TOOLTIP_CALLBACKS = {
+  // Null-safe: a tooltip `filter` can leave the active item set empty (chart.js
+  // still calls these), so never assume context[0]/raw exists.
+  title: (context: Array<TooltipItem<"line">>) => {
+    const dp = context[0]?.raw as DataPoint | undefined;
+    return dp ? format(new Date(dp.x), "MMMM do, yyyy HH:mm") : "";
+  },
+  label: (context: TooltipItem<"line">) =>
+    (context.raw as DataPoint | undefined)?.ether ?? "",
+};
+
+// Build the full options object by layering the caller's `options` over a fresh
+// copy of the shared defaults (with default tooltip callbacks). Rebuilding from
+// the defaults on every update — rather than merging into the live
+// chart.options — prevents stale keys (e.g. a previous range's x min/max, or
+// callbacks) from lingering when a later `options` object omits them.
+const buildChartOptions = (
+  options: Partial<ChartOptions<"line">>
+): ChartOptions<"line"> =>
+  merge(
+    set(
+      "plugins.tooltip.callbacks",
+      DEFAULT_TOOLTIP_CALLBACKS,
+      DEFAULT_LINE_CHART_OPTIONS
+    ),
+    options
+  );
+
 interface LineChartProps {
   datasets: DataPoint[][];
   datasetsConfigCallbacks: DatasetConfigCallback[];
   height: number;
   options?: Partial<ChartOptions<"line">>;
+  // Stable instance plugins. Chart.js instance plugins must be passed at chart
+  // construction, so this should be a stable (module-level) array. Per-render
+  // plugin state should be driven through `options` (each plugin reads its own
+  // `options.plugins[<id>]`), not by swapping the array.
+  plugins?: Plugin<"line">[];
 }
+
+const EMPTY_PLUGINS: Plugin<"line">[] = [];
 
 const LineChart: FC<LineChartProps> = ({
   datasets,
   datasetsConfigCallbacks,
   height,
   options = {},
+  plugins = EMPTY_PLUGINS,
 }) => {
   const theme = useTheme();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -44,29 +98,14 @@ const LineChart: FC<LineChartProps> = ({
       ...cb(canvasContext),
     }));
 
-    const defaultDatasetsOptions = set(
-      "plugins.tooltip.callbacks",
-      {
-        title: (context: Array<TooltipItem<"line">>) =>
-          format(
-            new Date((context[0]?.raw as DataPoint).x),
-            "MMMM do, yyyy HH:mm"
-          ),
-        label: (context: TooltipItem<"line">) =>
-          (context.raw as DataPoint).ether,
-      },
-      DEFAULT_LINE_CHART_OPTIONS
-    );
-
-    const datasetsOptions = merge(defaultDatasetsOptions, options);
-
     const chart = new Chart(canvasContext, {
       type: "line",
       data: {
         labels: [],
         datasets: initialDatasetsConfig,
       },
-      options: datasetsOptions,
+      options: buildChartOptions(options),
+      plugins,
     });
 
     chartRef.current = chart;
@@ -100,8 +139,7 @@ const LineChart: FC<LineChartProps> = ({
 
     if (!currentChart) return;
 
-    const newOptions = merge(currentChart.options, options);
-    mutateSet(currentChart, "options", newOptions);
+    mutateSet(currentChart, "options", buildChartOptions(options));
 
     currentChart.update();
   }, [chartRef, options]);

--- a/src/features/impersonation/ImpersonationContext.tsx
+++ b/src/features/impersonation/ImpersonationContext.tsx
@@ -20,6 +20,10 @@ import { useReverseResolveQuery } from "../whois/whoisApi.slice";
 interface ImpersonationContextValue {
   isImpersonated: boolean;
   impersonatedAddress: string | undefined;
+  // True while a `?view=` param is still being resolved into an impersonated
+  // address (sync for an address, async whois lookup for a name). Consumers
+  // that redirect on a missing visible address should wait on this.
+  isInitializingFromUrl: boolean;
   stopImpersonation: () => void;
   impersonate: (address: string) => void;
 }
@@ -35,13 +39,30 @@ export const ImpersonationProvider: FC<PropsWithChildren> = ({ children }) => {
     string | undefined
   >();
 
-  // Resolve ENS/handle names from view param via whois API
-  const viewParam = isString(router.query.view) ? router.query.view : undefined;
+  // Resolve ENS/handle names from view param via whois API. Gate on
+  // router.isReady so `?view=` is only considered once the query string is
+  // actually populated (it's empty on the first client render).
+  const viewParam =
+    router.isReady && isString(router.query.view)
+      ? router.query.view
+      : undefined;
   const isViewParamName = !!viewParam && !isAddress(viewParam);
-  const { data: resolvedName } = useReverseResolveQuery(
-    isViewParamName ? viewParam : "",
-    { skip: !isViewParamName || !router.isReady }
-  );
+  const { data: resolvedName, isLoading: isResolvingName } =
+    useReverseResolveQuery(isViewParamName ? viewParam : "", {
+      skip: !isViewParamName,
+    });
+  const resolvedAddress = resolvedName?.address;
+
+  // The page can't yet know the visible address while the URL param is still
+  // resolving — distinguish "resolving" from "resolved to nothing". For a name,
+  // stay "initializing" until the resolved address has actually been applied
+  // (whois resolving, OR resolved-but-not-yet-impersonated), so the page never
+  // redirects in the gap between resolution and impersonation.
+  const isInitializingFromUrl =
+    !!viewParam &&
+    !impersonatedAddress &&
+    (isAddress(viewParam) ||
+      (isViewParamName && (isResolvingName || !!resolvedAddress)));
 
   const removeImpersonatedAddressQueryParam = useCallback(() => {
     const { view: viewAddressQueryParam, ...queryWithoutParam } = router.query;
@@ -99,28 +120,34 @@ export const ImpersonationProvider: FC<PropsWithChildren> = ({ children }) => {
     () => ({
       impersonatedAddress,
       isImpersonated: !!impersonatedAddress,
+      isInitializingFromUrl,
       stopImpersonation,
       impersonate,
     }),
-    [impersonatedAddress, stopImpersonation, impersonate]
+    [impersonatedAddress, isInitializingFromUrl, stopImpersonation, impersonate]
   );
 
-  // Get impersonated address from query string
+  // Get impersonated address from the (address) view param. Depends only on
+  // viewParam so it resolves on client-side navigation and when the param
+  // changes to a different address — and crucially does NOT re-run when
+  // impersonatedAddress is cleared (which would re-impersonate during
+  // stopImpersonation before the URL param is removed). Setting the same value
+  // is a no-op render in React.
   useEffect(() => {
-    const { view: viewAddressQueryParam } = router.query;
-    if (!impersonatedAddress && isString(viewAddressQueryParam)) {
-      if (isAddress(viewAddressQueryParam)) {
-        setImpersonatedAddress(getAddress(viewAddressQueryParam));
-      }
+    if (viewParam && isAddress(viewParam)) {
+      setImpersonatedAddress(getAddress(viewParam));
     }
-  }, [router.isReady]);
+  }, [viewParam]);
 
-  // Resolve ENS/handle name from view param and impersonate
+  // Resolve ENS/handle name from view param and impersonate. Depends on the
+  // (name) param and the resolved address rather than on impersonatedAddress,
+  // so navigating to a new `?view=<name>` switches even when already
+  // impersonating — and so it doesn't re-fire on stopImpersonation.
   useEffect(() => {
-    if (!impersonatedAddress && resolvedName?.address) {
-      impersonate(resolvedName.address);
+    if (viewParam && !isAddress(viewParam) && resolvedAddress) {
+      impersonate(resolvedAddress);
     }
-  }, [resolvedName, impersonatedAddress, impersonate]);
+  }, [viewParam, resolvedAddress, impersonate]);
 
   // Actively keep impersonated address in query string
   useEffect(() => {

--- a/src/features/token/TokenGraph/TokenBalanceGraph.tsx
+++ b/src/features/token/TokenGraph/TokenBalanceGraph.tsx
@@ -38,6 +38,12 @@ const ALL_FALLBACK_FLOOR_UNIX = 1_609_459_200;
 const FORECAST_POINTS = 12;
 const FORECAST_MAX_DURATION_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
+// Number of balance-snapshot points requested, scaled with the visible window
+// (~1 per day) so longer periods get finer resolution. The Balances API caps
+// `points` at 200 (requests above return 200), so that's the ceiling.
+const MIN_POINTS = 50;
+const MAX_POINTS = 200;
+
 // The claimable (disconnected) series is gradient-filled only where it makes up
 // at least this share of the total balance — so it doesn't cover the green
 // connected gradient in periods with a meaningful connected balance.
@@ -221,7 +227,7 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     { skip: !isAll }
   );
 
-  const { startTimestamp, dateNow, forecastEndDate } = useMemo(() => {
+  const { startTimestamp, dateNow, forecastEndDate, points } = useMemo(() => {
     const currentDate = new Date();
     const currentUnix = getUnixTime(currentDate);
 
@@ -252,10 +258,21 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
       FORECAST_MAX_DURATION_SECONDS
     );
     const forecastEndUnix = currentUnix + forecastDurationUnix;
+
+    // Scale resolution with the window (~1 point/day), floored/capped. Span
+    // covers the tricky "All" case automatically: short history -> few points,
+    // long history -> capped. Guard against a non-positive span.
+    const spanDays = Math.max(0, (currentUnix - startUnix) / 86400);
+    const points = Math.min(
+      MAX_POINTS,
+      Math.max(MIN_POINTS, Math.round(spanDays))
+    );
+
     return {
       startTimestamp: startUnix,
       dateNow: currentDate,
       forecastEndDate: fromUnixTime(forecastEndUnix),
+      points,
     };
   }, [
     filter,
@@ -271,7 +288,7 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
       account,
       token,
       startTimestamp,
-      points: 50,
+      points,
     },
     // Wait for the "All" probe to resolve before firing — avoids a
     // throwaway request against a stale default window.
@@ -368,7 +385,7 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
       : [];
 
     // Replace the API's tail point with the RPC live value. The API
-    // emits 50 evenly-spaced points up to ~now, but its last point can
+    // emits evenly-spaced points up to ~now, but its last point can
     // be indexer-lagged (today's value is still yesterday's). Using
     // RPC for the right edge guarantees the chart shows the actual
     // current balance and connects cleanly to the forecast (also RPC).

--- a/src/features/token/TokenGraph/TokenBalanceGraph.tsx
+++ b/src/features/token/TokenGraph/TokenBalanceGraph.tsx
@@ -1,12 +1,27 @@
-import { Button, Skeleton, Stack, Typography, useTheme } from "@mui/material";
+import {
+  alpha,
+  Button,
+  Skeleton,
+  Stack,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import { Address } from "@superfluid-finance/sdk-core";
-import { ChartOptions } from "chart.js/auto";
+import {
+  Chart,
+  ChartOptions,
+  ChartType,
+  Plugin,
+  ScriptableLineSegmentContext,
+  TooltipItem,
+} from "chart.js/auto";
 import { fromUnixTime, getUnixTime, sub } from "date-fns";
 import { BigNumber, ethers } from "ethers";
 import { FC, useMemo } from "react";
 import LineChart, { DataPoint } from "../../../components/Chart/LineChart";
 import {
   buildDefaultDatasetConf,
+  createCTXGradient,
   getFilteredStartDate,
 } from "../../../utils/chartUtils";
 import balanceApi from "../../balance/balanceApi.slice";
@@ -22,6 +37,100 @@ import { rpcApi } from "../../redux/store";
 const ALL_FALLBACK_FLOOR_UNIX = 1_609_459_200;
 const FORECAST_POINTS = 12;
 const FORECAST_MAX_DURATION_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+// The claimable (disconnected) series is gradient-filled only where it makes up
+// at least this share of the total balance — so it doesn't cover the green
+// connected gradient in periods with a meaningful connected balance.
+const CLAIMABLE_DOMINANT_PERCENT = 80;
+
+// Claimable line/fill color — a muted yellow-green: same family as the green
+// primary line but less prominent. (Tweak here to taste.)
+const CLAIMABLE_COLOR = "#A8B84D";
+
+// Format a wei string to ether, clamping negatives to zero (balances are never
+// shown negative on the chart).
+const formatWeiClamped = (value: string): string => {
+  const wei = BigNumber.from(value);
+  return ethers.utils.formatEther(wei.gt(0) ? wei : BigNumber.from(0));
+};
+
+// Multi-line tooltip label for the balance chart. Historical points carry a
+// connected/disconnected/deposit/total breakdown; live and forecast points only
+// carry `ether`. Rows that are undefined (unavailable) or zero are omitted to
+// keep the tooltip compact.
+const balanceTooltipLabel = (
+  context: TooltipItem<"line">
+): string | string[] => {
+  const dp = context.raw as DataPoint | undefined;
+  if (!dp) return "";
+  const rows: string[] = [];
+  const pushRow = (label: string, value: string | undefined) => {
+    if (value !== undefined && Number(value) !== 0) {
+      rows.push(`${label}: ${value}`);
+    }
+  };
+  pushRow("Connected", dp.connected);
+  pushRow("Disconnected", dp.disconnected);
+  pushRow("Locked deposit", dp.deposit);
+  pushRow("Total", dp.total);
+  return rows.length > 0 ? rows : dp.ether;
+};
+
+interface LiquidationMarkerOptions {
+  at?: number | null; // epoch milliseconds
+  color?: string;
+  label?: string;
+}
+
+// Register the plugin's options on Chart.js so `options.plugins.liquidationMarker`
+// is type-checked.
+declare module "chart.js" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface PluginOptionsByType<TType extends ChartType> {
+    liquidationMarker?: LiquidationMarkerOptions;
+  }
+}
+
+// Draws a vertical dashed line at the projected liquidation (balance-hits-zero)
+// timestamp. Marker state is read from `options.plugins.liquidationMarker`, so
+// it updates via the options effect without recreating the chart.
+const liquidationMarkerPlugin: Plugin<"line", LiquidationMarkerOptions> = {
+  id: "liquidationMarker",
+  afterDatasetsDraw: (chart, _args, opts) => {
+    const at = opts?.at;
+    if (at == null) return;
+    const xScale = chart.scales.x;
+    if (!xScale) return;
+    const px = xScale.getPixelForValue(at);
+    const { top, bottom, left, right } = chart.chartArea;
+    if (px < left || px > right) return;
+
+    const { ctx } = chart;
+    const color = opts.color ?? "rgba(244, 67, 54, 0.7)";
+    ctx.save();
+    ctx.beginPath();
+    ctx.setLineDash([4, 4]);
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = color;
+    ctx.moveTo(px, top);
+    ctx.lineTo(px, bottom);
+    ctx.stroke();
+    if (opts.label) {
+      const alignRight = px > (left + right) / 2;
+      ctx.setLineDash([]);
+      ctx.fillStyle = color;
+      ctx.font = "10px sans-serif";
+      ctx.textAlign = alignRight ? "right" : "left";
+      ctx.fillText(opts.label, px + (alignRight ? -4 : 4), top + 10);
+    }
+    ctx.restore();
+  },
+};
+
+// Stable instance-plugin array (passed to Chart at construction).
+const LINE_CHART_PLUGINS: Plugin<"line">[] = [
+  liquidationMarkerPlugin as Plugin<"line">,
+];
 
 const projectBalanceAt = (
   realTimeBalance: RealtimeBalance,
@@ -61,6 +170,7 @@ const mapForecastDatesWithData = (
         x: zeroCrossingUnix * 1000,
         y: 0,
         ether: "0.0",
+        isLiquidation: true,
       });
       break;
     }
@@ -202,16 +312,60 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     const points = balanceHistoryQuery.data?.points ?? [];
 
     const balanceDataset: DataPoint[] = points.map((p) => {
-      const wei = BigNumber.from(p.connectedBalance);
-      const ether = ethers.utils.formatEther(
-        wei.gt(BigNumber.from(0)) ? wei : BigNumber.from(0)
-      );
+      const connected = formatWeiClamped(p.connectedBalance);
       return {
         x: Number(p.timestamp) * 1000,
-        y: Number(ether),
-        ether,
+        y: Number(connected),
+        ether: connected,
+        connected,
+        disconnected: formatWeiClamped(p.disconnectedBalance),
+        deposit: formatWeiClamped(p.deposit),
+        total: formatWeiClamped(p.totalBalance),
       };
     });
+
+    // Quiet supporting series, shown only when they carry non-zero values so
+    // the sparkline stays clean. Fixed dataset slots (empty arrays when hidden)
+    // — LineChart updates dataset data by index, so the slot count must be
+    // stable across renders.
+    const hasDeposit = points.some((p) => BigNumber.from(p.deposit).gt(0));
+    const hasClaimable = points.some((p) =>
+      BigNumber.from(p.disconnectedBalance).gt(0)
+    );
+
+    const depositDataset: DataPoint[] = hasDeposit
+      ? points.map((p) => {
+          const deposit = formatWeiClamped(p.deposit);
+          return {
+            x: Number(p.timestamp) * 1000,
+            y: Number(deposit),
+            ether: deposit,
+            deposit,
+          };
+        })
+      : [];
+
+    const claimableDataset: DataPoint[] = hasClaimable
+      ? points.map((p) => {
+          const disconnected = formatWeiClamped(p.disconnectedBalance);
+          const connectedWei = BigNumber.from(p.connectedBalance);
+          const disconnectedWei = BigNumber.from(p.disconnectedBalance);
+          const totalWei = connectedWei.add(disconnectedWei);
+          // disconnected / total >= CLAIMABLE_DOMINANT_PERCENT% (integer-safe).
+          const claimableDominant =
+            totalWei.gt(0) &&
+            disconnectedWei
+              .mul(100)
+              .gte(totalWei.mul(CLAIMABLE_DOMINANT_PERCENT));
+          return {
+            x: Number(p.timestamp) * 1000,
+            y: Number(disconnected),
+            ether: disconnected,
+            disconnected,
+            claimableDominant,
+          };
+        })
+      : [];
 
     // Replace the API's tail point with the RPC live value. The API
     // emits 50 evenly-spaced points up to ~now, but its last point can
@@ -219,15 +373,36 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     // RPC for the right edge guarantees the chart shows the actual
     // current balance and connects cleanly to the forecast (also RPC).
     if (realTimeBalanceQuery.data && balanceDataset.length > 0) {
-      const livePoint = projectBalanceAt(realTimeBalanceQuery.data, dateNow);
-      if (livePoint.x > balanceDataset[balanceDataset.length - 1].x) {
+      const apiTail = balanceDataset[balanceDataset.length - 1];
+      const liveBase = projectBalanceAt(realTimeBalanceQuery.data, dateNow);
+      // Connected comes from the live RPC value (accurate "now"); carry the most
+      // recent known claimable/deposit from the API tail so the "now" tooltip
+      // still shows them (they only lag the indexer slightly). Recompute total
+      // from the live connected + last-known claimable to stay consistent.
+      const connected = liveBase.ether;
+      const disconnected = apiTail.disconnected;
+      const total = disconnected
+        ? ethers.utils.formatEther(
+            ethers.utils
+              .parseEther(connected)
+              .add(ethers.utils.parseEther(disconnected))
+          )
+        : connected;
+      const livePoint: DataPoint = {
+        ...liveBase,
+        connected,
+        disconnected,
+        deposit: apiTail.deposit,
+        total,
+      };
+      if (livePoint.x > apiTail.x) {
         balanceDataset.pop();
       }
       balanceDataset.push(livePoint);
     }
 
     if (!showForecast || !realTimeBalanceQuery.data) {
-      return [balanceDataset, []];
+      return [balanceDataset, [], depositDataset, claimableDataset];
     }
 
     const forecastDates = getDatesBetween(
@@ -240,7 +415,7 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
       forecastDates
     );
 
-    return [balanceDataset, forecastDataset];
+    return [balanceDataset, forecastDataset, depositDataset, claimableDataset];
   }, [
     balanceHistoryQuery.data,
     realTimeBalanceQuery.data,
@@ -258,8 +433,54 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     const balanceDataset = datasets[0];
     const forecastDataset = datasets[1];
 
-    if (balanceDataset.length === 0) {
+    const lastForecast =
+      forecastDataset.length > 0
+        ? forecastDataset[forecastDataset.length - 1]
+        : undefined;
+    const lastHistoricalX =
+      balanceDataset.length > 0
+        ? balanceDataset[balanceDataset.length - 1].x
+        : undefined;
+
+    // Use the explicitly-tagged zero-crossing point (set only on a genuine
+    // negative-flow liquidation), and only when it lands in the future — past
+    // crossings or balances merely clamped to 0 must not draw a marker.
+    const liquidationPoint = forecastDataset.find((p) => p.isLiquidation);
+    const liquidationAt =
+      liquidationPoint &&
+      (lastHistoricalX === undefined || liquidationPoint.x >= lastHistoricalX)
+        ? liquidationPoint.x
+        : null;
+
+    // axis:"x" makes hover pick the nearest point horizontally; ties at a shared
+    // timestamp resolve to the first dataset (the connected line), so the quiet
+    // deposit/claimable lines never steal the breakdown tooltip.
+    const interaction = {
+      mode: "nearest" as const,
+      axis: "x" as const,
+      intersect: false,
+    };
+
+    const plugins = {
+      tooltip: {
+        // Only the connected (0) and forecast (1) datasets contribute tooltip
+        // rows; the supporting deposit/claimable series (2/3) are already folded
+        // into the connected point's breakdown, and `nearest` returns every
+        // dataset tied at the same x — which otherwise adds a stray bare "0.0".
+        filter: (item: TooltipItem<"line">) => item.datasetIndex <= 1,
+        callbacks: { label: balanceTooltipLabel },
+      },
+      liquidationMarker: {
+        at: liquidationAt,
+        color: theme.palette.error.main,
+        label: liquidationAt != null ? "Liquidation" : undefined,
+      },
+    };
+
+    if (balanceDataset.length === 0 || lastHistoricalX === undefined) {
       return {
+        interaction,
+        plugins,
         scales: {
           x: { offset: true },
           y: { offset: true },
@@ -268,19 +489,18 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
     }
 
     const firstX = balanceDataset[0].x;
-    const lastHistoricalX = balanceDataset[balanceDataset.length - 1].x;
-    const lastForecastX =
-      forecastDataset.length > 0
-        ? forecastDataset[forecastDataset.length - 1].x
-        : lastHistoricalX;
+    // Never let a forecast endpoint shrink the domain below the live tail.
+    const maxX = Math.max(lastHistoricalX, lastForecast?.x ?? lastHistoricalX);
 
     return {
+      interaction,
+      plugins,
       scales: {
-        x: { min: firstX, max: lastForecastX, offset: true },
+        x: { min: firstX, max: maxX, offset: true },
         y: { offset: true },
       },
     };
-  }, [datasets]);
+  }, [datasets, theme.palette.error.main]);
 
   const datasetsConfigCallbacks = useMemo(
     () => [
@@ -290,8 +510,56 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
         ...buildDefaultDatasetConf(ctx, theme.palette.secondary.main, height),
         borderDash: [6, 6],
       }),
+      // Locked deposit — faint blue shade, no line. Flat alpha (not a height
+      // gradient, which vanishes for the small deposit band near the bottom).
+      // Draws under the green connected fill, so it reads as a subtle blue tint
+      // of the bottom band.
+      (_ctx: CanvasRenderingContext2D) => ({
+        label: "Locked deposit",
+        backgroundColor: alpha(theme.palette.info.main, 0.12),
+        fill: true,
+        borderWidth: 0,
+        pointRadius: 0,
+        tension: 0.1,
+      }),
+      // Claimable (disconnected GDA/IDA) — quiet yellow-green line everywhere,
+      // with a matching gradient fill only on segments where claimable dominates
+      // the total (so it doesn't cover the green gradient where connected is
+      // meaningful).
+      (ctx: CanvasRenderingContext2D) => {
+        const grad = createCTXGradient(ctx, CLAIMABLE_COLOR, height);
+        return {
+          label: "Disconnected",
+          borderColor: CLAIMABLE_COLOR,
+          backgroundColor: grad,
+          fill: true,
+          borderWidth: 2,
+          pointRadius: 0,
+          pointBorderColor: "transparent",
+          pointBackgroundColor: "transparent",
+          tension: 0.1,
+          segment: {
+            // `chart` exists on the segment context at runtime but isn't on the
+            // public type, so cast to read it; the index fields are typed.
+            backgroundColor: (s: ScriptableLineSegmentContext) => {
+              const chart = (s as unknown as { chart: Chart<"line"> }).chart;
+              const data = chart.data.datasets[s.datasetIndex]
+                .data as unknown as DataPoint[];
+              return data[s.p0DataIndex]?.claimableDominant &&
+                data[s.p1DataIndex]?.claimableDominant
+                ? grad
+                : "transparent";
+            },
+          },
+        };
+      },
     ],
-    [height, theme.palette.primary.main, theme.palette.secondary.main]
+    [
+      height,
+      theme.palette.primary.main,
+      theme.palette.secondary.main,
+      theme.palette.info.main,
+    ]
   );
 
   if (balanceHistoryQuery.isLoading || firstMovementQuery.isLoading) {
@@ -314,6 +582,7 @@ const TokenBalanceGraph: FC<TokenBalanceGraphProps> = ({
       datasets={datasets}
       options={options}
       datasetsConfigCallbacks={datasetsConfigCallbacks}
+      plugins={LINE_CHART_PLUGINS}
     />
   );
 };

--- a/src/pages/token/[_network]/[_token].tsx
+++ b/src/pages/token/[_network]/[_token].tsx
@@ -43,6 +43,7 @@ import TokenToolbar from "../../../features/token/TokenToolbar";
 import FlowingFiatBalance from "../../../features/tokenPrice/FlowingFiatBalance";
 import useTokenPrice from "../../../features/tokenPrice/useTokenPrice";
 import TransferEventsTable from "../../../features/transfers/TransferEventsTable";
+import { useImpersonation } from "../../../features/impersonation/ImpersonationContext";
 import { useVisibleAddress } from "../../../features/wallet/VisibleAddressContext";
 import useNavigateBack from "../../../hooks/useNavigateBack";
 import Page404 from "../../404";
@@ -78,7 +79,8 @@ const TokenPage: NextPage = () => {
   const [network, setNetwork] = useState<Network | undefined>();
   const [tokenAddress, setTokenAddress] = useState<string | undefined>();
   const { visibleAddress } = useVisibleAddress();
-  const { isReconnecting } = useAccount();
+  const { isConnecting, isReconnecting } = useAccount();
+  const { isInitializingFromUrl } = useImpersonation();
 
   const [routeHandled, setRouteHandled] = useState(false);
 
@@ -93,10 +95,22 @@ const TokenPage: NextPage = () => {
   }, [setRouteHandled, router.isReady, router.query._token, router.query._network]);
 
   useEffect(() => {
-    if (!isReconnecting && !visibleAddress) {
+    if (!router.isReady) return; // wait for the query string (`?view=`)
+    // Don't redirect while a wallet is (re)connecting or while a `?view=`
+    // param is still resolving into an impersonated address — otherwise direct
+    // `/token/...?view=<address>` links bounce to home before impersonation
+    // hydrates.
+    if (isConnecting || isReconnecting || isInitializingFromUrl) return;
+    if (!visibleAddress) {
       router.push("/");
     }
-  }, [isReconnecting, visibleAddress]);
+  }, [
+    router.isReady,
+    isConnecting,
+    isReconnecting,
+    isInitializingFromUrl,
+    visibleAddress,
+  ]);
 
   const isPageReady = routeHandled && visibleAddress;
   if (!isPageReady) return <TokenPageContainer />;

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -30,7 +30,11 @@ export const DEFAULT_LINE_CHART_OPTIONS: ChartOptions<"line"> = {
   scales: {
     x: {
       display: false,
-      type: "logarithmic",
+      // Timestamps are epoch milliseconds, so the axis must be linear for
+      // points to be spaced proportionally to elapsed time. A logarithmic
+      // scale (the previous default) distorts the line geometry and hover
+      // hit-testing even while the axis is hidden.
+      type: "linear",
     },
     y: {
       display: false,


### PR DESCRIPTION
## Summary

Enhances the token balance chart to surface data the Balances API already returns, fixes a charting bug, and resolves a pre-existing redirect race that blocked viewing arbitrary accounts via shared links.

### Balance chart (`feat`)
- **X-axis bug fix:** the shared chart default plotted epoch-ms timestamps on a `logarithmic` scale, distorting point spacing/hover even while hidden → switched to `linear`. Also rebuild `LineChart` options from fresh defaults each update to avoid stale keys.
- **Richer tooltip:** date + **Connected / Disconnected / Locked deposit / Total** (zero/unavailable rows omitted), null-safe.
- **New supporting series** (previously-unused `balance-snapshots` fields):
  - Faint **blue deposit shade** (the locked CFA buffer).
  - **Disconnected** balance as a muted yellow-green line, gradient-filled only on segments where it's ≥ 80% of total (so it never covers the connected gradient).
- **Liquidation marker:** vertical line at the forecast's projected zero-crossing.

### Impersonation redirect fix (`fix`)
`/token/<network>/<token>?view=<address>` redirected to home when no wallet was connected (the page redirected before URL impersonation hydrated). Now gated on `router.isReady` + a new `isInitializingFromUrl` flag + connect/reconnect state; the address effect also resolves off the `?view=` param (works on client-side nav, handles name switching, avoids a `stopImpersonation` re-impersonation race).

### Chore
- Bump version to **42.0.0**; use `--webpack` for `dev` (matches `build`, works around Next 16 turbopack).

## Test plan
- `pnpm typecheck` and `pnpm lint` pass.
- Manual review on Base (no wallet needed thanks to the redirect fix):
  - Pure disconnected (SUP): `/token/base/0xa69f80524381275a7ffdb3ae01c54150644c8792?view=0x5d13b662a387a0e40b9320b8759e38c1204ec5ea`
  - Connected + disconnected (SUP): `/token/base/0xa69f80524381275a7ffdb3ae01c54150644c8792?view=0xd2db6ab0dc4743a77719b38d9f7196aa32fa519f`
  - Draining USDCx (deposit shade + liquidation marker, use 3M/All): `/token/base/0xd04383398dd2426297da660f9cca3d439af9ce1b?view=0x6a870312a810409ff4f1e8ff2a2724ad8820fd70`

🤖 Generated with [Claude Code](https://claude.com/claude-code)