### PR TITLE
feat(clear-macro): Enable gasless relay on Base, Arbitrum and Optimism mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ NEXT_PUBLIC_OPENSEA_API_KEY=
 NEXT_PUBLIC_ALLOWLIST_API="https://allowlist.superfluid.dev"
 NEXT_PUBLIC_INTERFACE_FEE_ADDRESS=
 
+# Clear Macro
+# Kill switch for the gasless relay. Unset = enabled; set to "true" to disable
+# the relay UI and force all writes through the normal transaction path.
+NEXT_PUBLIC_DISABLE_CLEAR_MACRO=
+
 # Netlify
 URL=
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           submodules: recursive
 
+      # Pinned so CI matches the toolchain deployments are built with; see
+      # docs/plans/clear-macro-multi-network-deploy.md on build reproducibility.
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
 
       - name: Build contracts
         run: forge build --root contracts

--- a/.github/workflows/deploy-clear-macro.yml
+++ b/.github/workflows/deploy-clear-macro.yml
@@ -5,6 +5,11 @@ name: Deploy Clear Macro
 # contracts/script/DeployDashboardClearMacro.s.sol; the only inputs CI supplies are the target
 # network(s) and the deployer credentials.
 #
+# Three mutually exclusive modes, selected by the inputs:
+#   broadcast=true             -> deploy job:   broadcast, then verify as a separate step
+#   broadcast=false, no run_id -> simulate job: dry run only
+#   broadcast=false, run_id=N  -> verify job:   re-verify the deployment recorded by run N
+#
 # Required secrets (for broadcast runs):
 #   BUILD_AGENT_MNEMONIC  org secret; BIP-39 mnemonic of the deployer; the account at derivation
 #                         index 0 is used (expected 0xd15d5d0f5b1b56a4daef75cfe108cb825e97d015,
@@ -15,6 +20,10 @@ name: Deploy Clear Macro
 # Security model: anyone with repo write access can dispatch a broadcast — deliberate, no approval
 # gate. A deployed macro is inert until its address lands in src/features/network/networks.ts via
 # a reviewed PR, so dashboard code review is the effective gate for user-facing impact.
+#
+# The deploy is a plain CREATE, so re-dispatching a broadcast deploys a SECOND contract at a new
+# address rather than resuming — it is never the right response to a failed verification. Use the
+# verify-only mode (run_id) for that.
 
 on:
   workflow_dispatch:
@@ -40,9 +49,14 @@ on:
         type: boolean
         default: false
       verify:
-        description: "Verify on the explorer after broadcast"
+        description: "Verify on the explorer after broadcast (broadcast runs only)"
         type: boolean
         default: true
+      run_id:
+        description: "Verify-only: re-verify the deployment from this run id (leave empty to simulate)"
+        type: string
+        required: false
+        default: ""
 
 concurrency:
   group: deploy-clear-macro
@@ -50,22 +64,36 @@ concurrency:
 
 jobs:
   simulate:
-    if: ${{ !inputs.broadcast }}
+    if: ${{ !inputs.broadcast && !inputs.run_id }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
 
       - name: Simulate deployment
+        env:
+          NETWORK: ${{ inputs.network }}
         run: |
           set -o pipefail
-          ./contracts/script/deploy-clear-macro.sh "${{ inputs.network }}" | tee deploy.log
+          forge --version
+          ./contracts/script/deploy-clear-macro.sh "$NETWORK" | tee deploy.log
+
+      # Dry runs write to a *different* path than broadcasts — note the extra dry-run/ level.
+      - name: Upload dry-run records
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: clear-macro-dryrun-${{ inputs.network }}-${{ github.run_id }}
+          path: contracts/broadcast/DeployDashboardClearMacro.s.sol/*/dry-run/run-latest.json
+          if-no-files-found: warn
 
       - name: Job summary
         if: always()
@@ -75,6 +103,8 @@ jobs:
             echo '```'
             tail -n 60 deploy.log 2>/dev/null || echo "no output"
             echo '```'
+            echo 'Simulation predicts an address for forge'"'"'s default sender, NOT the real deployer —'
+            echo 'the address a broadcast produces will differ.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -83,43 +113,146 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
 
+      # Deploy and verify are deliberately separate steps: an explorer verification queue can
+      # outlast forge's retry budget long after the contract is safely deployed, and a red job
+      # invites a re-dispatch that would deploy a duplicate.
       - name: Deploy
+        id: deploy
         env:
           DEPLOYER_MNEMONIC: ${{ secrets.BUILD_AGENT_MNEMONIC }}
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          NETWORK: ${{ inputs.network }}
         run: |
           set -o pipefail
-          ARGS=(--broadcast)
-          if [ "${{ inputs.verify }}" = "true" ]; then
-            ARGS+=(--verify)
-          fi
-          ./contracts/script/deploy-clear-macro.sh "${ARGS[@]}" "${{ inputs.network }}" | tee deploy.log
+          forge --version
+          ./contracts/script/deploy-clear-macro.sh --broadcast "$NETWORK" | tee deploy.log
 
       # The broadcast records are gitignored, so the workflow artifact is the durable record of
-      # what was deployed with which constructor args. Uploaded even if verification failed.
+      # what was deployed with which constructor args. Uploaded before verification runs, so the
+      # record survives even if verification hangs or the job times out.
       - name: Upload broadcast records
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: clear-macro-broadcast-${{ inputs.network }}-${{ github.run_id }}
           path: contracts/broadcast/DeployDashboardClearMacro.s.sol/*/run-latest.json
-          if-no-files-found: warn
+          # A successful deploy MUST leave records — without them there is no recovery path, so
+          # treat that as a failure. A failed deploy may legitimately have produced nothing.
+          if-no-files-found: ${{ steps.deploy.outcome == 'success' && 'error' || 'warn' }}
+
+      - name: Verify
+        id: verify
+        if: ${{ inputs.verify }}
+        continue-on-error: true
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          set -o pipefail
+          ./contracts/script/deploy-clear-macro.sh --verify "$NETWORK" | tee -a deploy.log
 
       - name: Job summary
         if: always()
         run: |
           {
             echo '## Clear Macro deployment (broadcast)'
+            echo ''
+            echo "- Deploy: ${{ steps.deploy.outcome }}"
+            echo "- Verify: ${{ inputs.verify && steps.verify.outcome || 'skipped' }}"
+            echo ''
             echo '```'
             tail -n 60 deploy.log 2>/dev/null || echo "no output"
             echo '```'
+            if [ "${{ steps.deploy.outcome }}" = "success" ] && [ "${{ steps.verify.outcome }}" = "failure" ]; then
+              echo 'Verification did not complete, but THE DEPLOYMENT SUCCEEDED. Do not re-dispatch a'
+              echo 'broadcast — that deploys a duplicate. Re-run this workflow with broadcast unchecked'
+              echo "and run_id=${{ github.run_id }} to verify only. Explorer queues often finish on their"
+              echo 'own after forge gives up, so check the explorer first.'
+            fi
             echo 'Next: wire the printed macroAddress into src/features/network/networks.ts'
             echo 'and extend the lineage comment in src/features/clearMacro/dashboardClearMacro.ts.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Verify-only recovery path: re-runs verification against a previous run's broadcast record,
+  # without redeploying. Limited by artifact retention (90 days by default); after that, verify
+  # manually with `forge verify-contract` and args re-derived from _defaultConfig.
+  #
+  # Caveat for deployments made BEFORE Foundry was pinned and auto_detect_remappings disabled
+  # (i.e. runs at or before 2026-07-20): those were built with a floating nightly, so recompiling
+  # them here may not reproduce their metadata even at the right commit, and verification can fail
+  # for reasons unrelated to the deployment. Deployments made after that fix reproduce reliably.
+  verify:
+    if: ${{ !inputs.broadcast && inputs.run_id }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      # Verification recompiles from source, so it must use the exact commit the deployment was
+      # built from — not whatever the dispatch ref points at now. Any source, remapping or
+      # compiler-setting change since would otherwise produce different bytecode and fail (or,
+      # worse, publish the wrong source). gh needs no checkout to resolve this.
+      - name: Resolve the source run's commit
+        id: src
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -o pipefail
+          SHA="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json headSha -q .headSha)"
+          [ -n "$SHA" ] || { echo "could not resolve headSha for run $RUN_ID" >&2; exit 1; }
+          echo "Verifying against $SHA (from run $RUN_ID)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.src.outputs.sha }}
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+
+      # The artifact preserves its <chainId>/ directory level, so it unpacks straight into the
+      # path verify_latest() reads. Fails loudly if the artifact is missing or has expired.
+      - name: Download broadcast records from run ${{ inputs.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NETWORK: ${{ inputs.network }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -o pipefail
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "clear-macro-broadcast-$NETWORK-$RUN_ID" \
+            --dir contracts/broadcast/DeployDashboardClearMacro.s.sol/
+          find contracts/broadcast/DeployDashboardClearMacro.s.sol -name run-latest.json
+
+      - name: Verify
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          set -o pipefail
+          ./contracts/script/deploy-clear-macro.sh --verify "$NETWORK" | tee verify.log
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo '## Clear Macro verification (from run ${{ inputs.run_id }})'
+            echo '```'
+            tail -n 60 verify.log 2>/dev/null || echo "no output"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -8,6 +8,16 @@ evm_version = "cancun"
 optimizer = true
 optimizer_runs = 200
 
+# Remappings are declared exhaustively and auto-detection is OFF. Forge otherwise discovers extra
+# remappings by walking the nested submodule tree under lib/superfluid-protocol-monorepo/lib/, and
+# although none of them affect codegen, they land in the compiler metadata — so any variation in
+# what the walk finds changes the metadata IPFS hash embedded in the deployed bytecode. That
+# actually happened: the arbitrum-one deploy of DashboardClearMacro got a different metadata hash
+# than base/optimism/optimism-sepolia despite identical source, commit and executable bytecode.
+# See docs/plans/clear-macro-multi-network-deploy.md. Adding a dependency now needs its remapping
+# added here by hand.
+auto_detect_remappings = false
+
 remappings = [
     "@superfluid-finance/ethereum-contracts/=lib/superfluid-protocol-monorepo/packages/ethereum-contracts/",
     "@superfluid-finance/solidity-semantic-money/=lib/superfluid-protocol-monorepo/packages/solidity-semantic-money/",

--- a/contracts/script/deploy-clear-macro.sh
+++ b/contracts/script/deploy-clear-macro.sh
@@ -150,8 +150,11 @@ verify_latest() { # <network> <chainId>
   local verifier_args=(--chain "$chain_id" --etherscan-api-key "$ETHERSCAN_API_KEY")
 
   echo "--- Verifying $network: $address"
+  # Explorer queues regularly outlast the default --watch budget (~90s); 20x15s gives ~5 minutes.
+  # A timeout here does NOT mean verification failed — Etherscan often completes it afterwards.
   forge verify-contract "$address" src/DashboardClearMacro.sol:DashboardClearMacro \
-    --root "$REPO_ROOT/contracts" "${verifier_args[@]}" --constructor-args "$encoded_args" --watch
+    --root "$REPO_ROOT/contracts" "${verifier_args[@]}" --constructor-args "$encoded_args" \
+    --watch --retries 20 --delay 15
 }
 
 deployed_address_for() { # <chainId>; prints the checksummed address from the latest broadcast, or "-"
@@ -166,6 +169,8 @@ deployed_address_for() { # <chainId>; prints the checksummed address from the la
 }
 
 SUMMARY=()
+VERIFY_FAILURES=()
+LOOP_COMPLETED=false
 
 # Printed via an EXIT trap so a mid-run failure (e.g. one RPC down during `all`) still reports the
 # networks already broadcast — those deployments are final even though the run aborted.
@@ -173,7 +178,7 @@ print_summary() {
   local status=$?
   [[ ${#SUMMARY[@]} -gt 0 ]] || return 0
   echo
-  if [[ $status -ne 0 ]]; then
+  if [[ $status -ne 0 ]] && ! $LOOP_COMPLETED; then
     echo "RUN FAILED (exit $status) — summary below covers only the networks completed before the failure."
   fi
   echo "network | chainId | macroAddress"
@@ -221,9 +226,25 @@ for network in "${NETWORKS[@]}"; do
   fi
 
   if $VERIFY; then
-    verify_latest "$network" "$chain_id"
+    # Deliberately NOT under `set -e`: a failed verification must not abandon the remaining
+    # networks. Unlike a failed broadcast (where stopping is right — later chains are untouched
+    # and the run can be re-dispatched), verification is independent per chain and a single
+    # explorer timeout should not strand the rest. Failures are aggregated and reported at exit.
+    if ! verify_latest "$network" "$chain_id"; then
+      VERIFY_FAILURES+=("$network")
+    fi
     if ! $BROADCAST; then
       SUMMARY+=("$network|$chain_id|$(deployed_address_for "$chain_id")")
     fi
   fi
 done
+
+LOOP_COMPLETED=true
+
+if [[ ${#VERIFY_FAILURES[@]} -gt 0 ]]; then
+  echo
+  echo "VERIFICATION FAILED on: ${VERIFY_FAILURES[*]}"
+  echo "The deployments themselves are unaffected. Explorer queues often finish after forge gives"
+  echo "up — check the explorer before retrying, then re-run with --verify for those networks."
+  exit 1
+fi

--- a/docs/plans/clear-macro-multi-network-deploy.md
+++ b/docs/plans/clear-macro-multi-network-deploy.md
@@ -1,6 +1,25 @@
 # Clear Macro: multi-network deployment tooling
 
-Status: implemented (tooling only — no new network has been broadcast to yet). 2026-07-09.
+Status: deployed on 4 of 9 eligible networks and wired up in the app. Tooling 2026-07-09;
+first multi-network rollout and pipeline hardening 2026-07-20.
+
+## Deployed instances
+
+All four are the same build from master `28aa6ab2`, Etherscan-verified, at base fee 0.1 paying the
+Superfluid DAO Safe `0xac808840f02c47C05507f48165d2222FF28EF4e1`:
+
+| network | chainId | macro address |
+|---|---|---|
+| optimism-sepolia | 11155420 | `0x96ec6a06fb72c8C3e42E9DD3ae3525e7847078c3` |
+| base-mainnet | 8453 | `0xC04FE9940e460457B75C3Aa4871bF142E0f49744` |
+| arbitrum-one | 42161 | `0x3BDd82FFbCcB9DBD0c233Ecd950642edbF60D667` |
+| optimism-mainnet | 10 | `0x4D11B0b59948d81EEAaF667CCDaA212f824949d4` |
+
+Not yet deployed: eth-mainnet, bsc-mainnet, xdai-mainnet, polygon-mainnet, avalanche-c.
+
+**Open follow-up:** the DAO Safe has no code on optimism-mainnet, arbitrum-one or optimism-sepolia.
+Fees accrue there from the moment each address is wired into `networks.ts` and are only retrievable
+once the Safe is instantiated at that address on those chains.
 
 ## Goal
 
@@ -29,7 +48,7 @@ networks** qualify:
 | base-mainnet | 8453 | USDCx `0xD04383398dD2426297da660F9CCA3d439AF9ce1b` |
 | arbitrum-one | 42161 | USDCx (native USDC) `0xFc55F2854e74b4f42D01a6d3DAAC4c52D9dfdcFf` |
 | avalanche-c | 43114 | USDCx `0x288398F314D472B82C44855F3f6fF20b633c2A97` |
-| optimism-sepolia | 11155420 | fUSDCx `0x131780640EDf9830099AAc2203229073d6D2FE69` (already deployed: `0xEeFC8492f24898289E65Ee06dE7B8A19F30832a5`) |
+| optimism-sepolia | 11155420 | fUSDCx `0x131780640EDf9830099AAc2203229073d6D2FE69` |
 
 Celo, Degen, Scroll (+Sepolia), Avalanche Fuji, Sepolia and Base Sepolia have **no FlowScheduler** and
 cannot receive the macro. If one gains a FlowScheduler later, add a row to `_defaultConfig` and to the
@@ -50,9 +69,11 @@ network's block in `src/features/network/networks.ts`.
 - **fee policy** (per-network configurable in the table; currently uniform): base fee `0.1e18` (must stay
   a multiple of `1e13`; raised from `0.01e18` on 2026-07-13), receiver
   `0xac808840f02c47C05507f48165d2222FF28EF4e1` (Superfluid DAO Safe, dao.superfluid.eth; changed
-  2026-07-14 from the dedicated fee EOA `0x74cD5673dF7efC148067Ecab494A19a46b0a3167`, which the
-  deployed OP Sepolia instance still uses). The Safe has code on eth-mainnet and Base today; on the
-  other chains it can be re-instantiated at the same address before fees are collected. A new
+  2026-07-14 from the dedicated fee EOA `0x74cD5673dF7efC148067Ecab494A19a46b0a3167` — the OP Sepolia
+  redeploy on 2026-07-20 resolved that discrepancy, so all live instances now pay the Safe). Verified
+  2026-07-20: the Safe has code only on **eth-mainnet and base-mainnet**; on the other 7 eligible
+  chains it can be re-instantiated at the same address (Safe factory replay) before fees are
+  collected — accepted deliberately, but it is an assumption, not a guarantee. A new
   schedule pays 2x base per
   reserved keeper execution on top of the 1x relay fee (3x with one scheduled date, 5x with both);
   modify/cancel stay 1x. Fee config is immutable per deployment — changing it means redeploying.
@@ -78,7 +99,16 @@ RPC_URL_8453=https://... pnpm contracts:deploy base-mainnet   # RPC override
   takes the plain keystore filename (e.g. `hacked_dev`), not the `0x`-prefixed name `cast wallet list` shows.
 - `--verify` needs `ETHERSCAN_API_KEY` (Etherscan v2 multichain API) on every chain, OP Sepolia included.
   Verification args are read back from `contracts/broadcast/.../run-latest.json` so they always match the
-  instance actually deployed.
+  instance actually deployed. That record is gitignored, so to verify a *CI* deployment locally, first
+  pull the run's artifact into place (the archive preserves its `<chainId>/` level):
+
+  ```bash
+  gh run download <run id> --repo superfluid-org/superfluid-dashboard \
+    --name "clear-macro-broadcast-<network>-<run id>" \
+    --dir contracts/broadcast/DeployDashboardClearMacro.s.sol/
+  ```
+
+  Or just dispatch the workflow with `broadcast` unchecked and `run_id=<run id>`, which does this.
 
 After a real deployment (per network):
 
@@ -92,8 +122,30 @@ After a real deployment (per network):
 `.github/workflows/deploy-clear-macro.yml` runs the same driver from GitHub Actions,
 **manual dispatch only** (Actions → "Deploy Clear Macro" → Run workflow):
 
+Three mutually exclusive modes, selected by the inputs:
+
+| inputs | job | what it does |
+|---|---|---|
+| `broadcast=true` | `deploy` | broadcasts, then verifies as a **separate** step |
+| `broadcast=false`, `run_id` empty | `simulate` | dry run only |
+| `broadcast=false`, `run_id=N` | `verify` | re-verifies the deployment recorded by run N, no redeploy |
+
 - Inputs: `network` (choice of the 9 eligible chains or `all`), `broadcast` (default off → simulation),
-  `verify` (default on, only applied with broadcast).
+  `verify` (default on; applies to broadcast runs only), `run_id` (verify-only recovery).
+- **Deploy and verify are separate steps** in the broadcast job, and verification is
+  `continue-on-error`. An explorer queue can outlast forge's retry budget long after the contract is
+  safely deployed; conflating the two made a successful mainnet deploy look like a failed job, which
+  invites a re-dispatch — and since this is a plain CREATE deploy, re-dispatching produces a *second*
+  contract at a new address rather than resuming. The job summary reports deploy and verify status
+  separately and, on verify failure, prints the exact verify-only re-run instruction.
+- The verify-only job downloads the target run's artifact into
+  `contracts/broadcast/DeployDashboardClearMacro.s.sol/` (the artifact preserves its `<chainId>/`
+  level, so it unpacks straight into the path `verify_latest` reads) and needs `actions: read`.
+  Bounded by artifact retention — 90 days by default; after that, verify manually with
+  `forge verify-contract` and args re-derived from `_defaultConfig`.
+- Foundry is pinned (`foundry-rs/foundry-toolchain@v1` with `version: v1.7.1`) in both this workflow
+  and `contracts.yml`, and the deploy job logs `forge --version`. See the retrospective on build
+  reproducibility for why.
 - All per-chain settings stay hardcoded in the repo's scripts; CI supplies only the credentials:
   the org secret `BUILD_AGENT_MNEMONIC` (BIP-39 mnemonic of the funded deployer, account at
   derivation index 0, expected 0xd15d5d0f5b1b56a4daef75cfe108cb825e97d015 — the driver's
@@ -104,7 +156,11 @@ After a real deployment (per network):
   `src/features/network/networks.ts` in a reviewed PR — that review is the effective gate.
 - The gitignored `broadcast/*/run-latest.json` records are uploaded as a workflow artifact
   (`clear-macro-broadcast-<network>-<run id>`) — the durable record of what was deployed with which
-  constructor args. The job summary shows the driver output including the `networks.ts` snippets.
+  constructor args. Uploaded *before* verification runs, so the record survives a verify hang. The
+  job summary shows the driver output including the `networks.ts` snippets.
+- Simulations upload their records too (`clear-macro-dryrun-<network>-<run id>`). Note dry runs write
+  to a different path — `.../<chainId>/dry-run/run-latest.json` — which the broadcast job's glob does
+  not match.
 - A concurrency group serializes runs so two deployments never race.
 
 ## Mainnet rollout caveat
@@ -131,3 +187,49 @@ independent), but the end-to-end flow on new networks inherits this blocker.
   (unused) immutables — now zeroed; unknown chains initially fell through to a silently feeless deploy —
   `BASE_FEE_AMOUNT` is now required there; broadcast-record extraction now filters CREATEs by
   `contractName == "DashboardClearMacro"` instead of taking the first one.
+
+### First multi-network rollout, 2026-07-20
+
+- **A verification timeout is not a deploy failure.** The base-mainnet run deployed successfully, then
+  went red because Etherscan's queue outlasted `forge verify-contract --watch` (~90s by default).
+  Etherscan finished on its own minutes later; the contract had been fine the whole time. Fixed three
+  ways: deploy and verify are separate steps, verify is `continue-on-error`, and the retry budget is
+  now `--retries 20 --delay 15` (~5 min). **Always check the explorer before concluding anything from
+  a red job**, and never respond to one by re-dispatching a broadcast.
+- **Simulations predict a meaningless address.** With no wallet configured, `forge script` falls back
+  to its built-in default sender `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`, so a dry run reports
+  that sender's next CREATE address — `0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519` at nonce 0. That
+  address is shared by every Foundry user on earth and has unrelated traffic on mainnet explorers.
+  It has no relationship to where a real broadcast lands. The simulate job's summary now says so.
+- **Builds were not byte-reproducible across CI runs.** arbitrum-one's deployment came out with a
+  different metadata IPFS hash than base / optimism / optimism-sepolia, despite identical source,
+  identical commit `28aa6ab2`, identical solc 0.8.30 and byte-identical *executable* bytecode. Cause:
+  `forge` auto-detected 8 remappings beyond the 7 declared in `foundry.toml` by walking the nested
+  submodule tree under `lib/superfluid-protocol-monorepo/lib/`. None are used by the contract so
+  codegen is unaffected, but `settings.remappings` is part of the compiler metadata, so any variation
+  in what the walk finds changes the metadata hash embedded in the deployed bytecode. Fixed with
+  `auto_detect_remappings = false` plus the pinned Foundry version. Consequence while it was
+  unfixed: full deployed bytecode and `EXTCODEHASH` differ between chains, so exact-bytecode
+  monitoring or allowlists would flag arbitrum-one as a different contract, and Sourcify-style
+  verification treats it as a distinct build.
+- **How to compare builds.** The trailing metadata hash is *not* a build fingerprint. Compare code
+  size, then mask the artifact's `immutableReferences` spans and truncate before the CBOR metadata
+  block before hashing. Derive that offset rather than hardcoding it: the last two bytes are a
+  big-endian length `L` of the CBOR block, so it starts at `len(code) - 2 - L`. For the current
+  19,879-byte build `L = 0x0033 = 51`, giving offset **19826** (the 32-byte IPFS hash itself starts
+  10 bytes later, at 19836, after the `a2646970667358221220` header). Size alone is what correctly
+  identified the two superseded 19,852-byte instances; the metadata hash alone would have given a
+  false negative on arbitrum-one.
+- **CREATE2 was analysed and deferred.** The appealing idea — "one version, one address on every
+  chain" — does not follow from CREATE2 alone, because the CREATE2 address depends on
+  `keccak256(initcode)` and initcode embeds the ABI-encoded constructor args, which are chain-specific
+  here (`host`, `flowScheduler`, `feeSuperToken`). CREATE2 as-is would buy only idempotency: a second
+  broadcast reverts instead of silently duplicating (~1-2h of work). True cross-chain parity would
+  additionally require moving `_defaultConfig` into the contract constructor keyed on `block.chainid`
+  so the constructor takes zero args (~1 day) — at the cost of the `FEE_RECEIVER` /
+  `BASE_FEE_AMOUNT=0` overrides, which break parity by definition, and of redeploying every live
+  chain to join. The deterministic deployment proxy `0x4e59b44847b379578588920cA78FbF26c0B4956C` is
+  present on all 9 eligible chains, and the contract has 4,697 bytes of size headroom, so both shapes
+  are feasible. **Note the ordering constraint:** initcode also embeds the metadata block, so
+  reproducible builds are a *precondition* for CREATE2 parity — without the remappings fix above,
+  even the zero-args design would produce different addresses per chain.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "60.0.0",
+  "version": "61.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/clearMacro/ClearMacroRelayOption.tsx
+++ b/src/features/clearMacro/ClearMacroRelayOption.tsx
@@ -12,6 +12,8 @@ import { alpha } from "@mui/material/styles";
 import { FC, useEffect } from "react";
 import { formatUnits, Hex } from "viem";
 import { useWaitForTransactionReceipt } from "wagmi";
+import { CLEAR_MACRO_LEARN_MORE_URL } from "../../utils/constants";
+import Link from "../common/Link";
 import TooltipWithIcon from "../common/TooltipWithIcon";
 import { Network } from "../network/networks";
 import ConnectionBoundary from "../transactionBoundary/ConnectionBoundary";
@@ -49,6 +51,33 @@ const formatBalance = (wei: bigint, decimals: number) =>
   Number(formatUnits(wei, decimals)).toLocaleString(undefined, {
     maximumFractionDigits: 2,
   });
+
+/**
+ * The "Powered by Clear Macro." attribution that closes both help tooltips, with the
+ * product name linking out to the public explainer. MUI tooltips are interactive by
+ * default, so the link stays reachable while the pointer travels into the tooltip —
+ * do not add `disableInteractive` to the tooltips carrying this.
+ */
+const PoweredByClearMacro: FC = () => (
+  <>
+    {" "}
+    Powered by{" "}
+    <Link
+      data-cy="clear-macro-learn-more-link"
+      href={CLEAR_MACRO_LEARN_MORE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      color="inherit"
+      sx={{ textDecoration: "underline" }}
+    >
+      Clear Macro
+    </Link>
+    .
+  </>
+);
+
+/** Touch users need time to travel from the info icon into the tooltip to tap the link. */
+const LINK_TOOLTIP_PROPS = { leaveTouchDelay: 10000 } as const;
 
 const feeChipSx = {
   height: 20,
@@ -203,7 +232,17 @@ export const ClearMacroRelayOption: FC<ClearMacroRelayOptionProps> = ({
           >
             Gasless transactions aren&apos;t available for this wallet type
           </Typography>
-          <TooltipWithIcon title="Gasless transactions currently only support regular wallet accounts. Transactions from this wallet are sent the normal way instead." />
+          <TooltipWithIcon
+            TooltipProps={LINK_TOOLTIP_PROPS}
+            title={
+              <>
+                Gasless transactions currently only support regular wallet
+                accounts. Transactions from this wallet are sent the normal way
+                instead.
+                <PoweredByClearMacro />
+              </>
+            }
+          />
         </Paper>
       );
     }
@@ -235,7 +274,7 @@ export const ClearMacroRelayOption: FC<ClearMacroRelayOptionProps> = ({
   // While a schedule quote is loading/unquotable the text is the worst-case placeholder,
   // so the sentence must not read as an exact, already-quoted amount.
   const isFeePlaceholder = actionKind === "scheduleFlow" && !fee.isQuoteExact;
-  const tooltip = fee.feeAvailable
+  const tooltipText = fee.feeAvailable
     ? `You sign a message instead of paying gas. The transaction is submitted for you and the network fee is covered. A ${isFeePlaceholder ? `service fee of ${fee.feeText}` : `${fee.feeText} service fee`} is charged only if it succeeds.` +
       (actionKind === "scheduleFlow"
         ? isFeePlaceholder
@@ -244,9 +283,8 @@ export const ClearMacroRelayOption: FC<ClearMacroRelayOptionProps> = ({
         : "") +
       (canPayWithUsdc
         ? ` You can pay the fee with ${fee.feeSymbol} or with ${underlyingSymbol}, which is converted automatically as part of the same transaction (after a one-time ${underlyingSymbol} approval).`
-        : "") +
-      " Powered by Clear Macro."
-    : "You sign a message instead of paying gas. The transaction is submitted for you and the network fee is covered. Powered by Clear Macro.";
+        : "")
+    : "You sign a message instead of paying gas. The transaction is submitted for you and the network fee is covered.";
 
   const showRelayRequiredWarning = Boolean(relayRequired) && !isRelayEnabled;
 
@@ -311,7 +349,15 @@ export const ClearMacroRelayOption: FC<ClearMacroRelayOptionProps> = ({
             </Typography>
           )}
         </Stack>
-        <TooltipWithIcon title={tooltip} />
+        <TooltipWithIcon
+          TooltipProps={LINK_TOOLTIP_PROPS}
+          title={
+            <>
+              {tooltipText}
+              <PoweredByClearMacro />
+            </>
+          }
+        />
       </Stack>
 
       {showPaymentSelector && (

--- a/src/features/clearMacro/dashboardClearMacro.ts
+++ b/src/features/clearMacro/dashboardClearMacro.ts
@@ -2,32 +2,47 @@ import { type Address, stringToHex } from "viem";
 
 /**
  * DashboardClearMacro ABI, generated from the Foundry project in `contracts/`
- * (regenerate with `pnpm contracts:abi`). The deployed OP Sepolia instance
- * (0xEde7e7d71AE56af5CcF8f36952f9bb85FB16fC2d, set in networks.ts) is the five-arg
- * fee-charging macro from contracts/script/DeployDashboardClearMacro.s.sol —
- * fee token fUSDCx 0x131780640eDF9830099AaC2203229073D6D2FE69, base fee 0.1,
- * fee receiver 0x74cD5673dF7efC148067Ecab494A19a46b0a3167 (a fresh empty address, so
- * arriving fees are visible as its whole balance) — so every action AND the fee reads
- * (`previewRelayFee`/`feeToken`/`baseFee`) are live on-chain. Fees are charged in
- * units of the base fee: 1 per relayed action plus 2 per reserved keeper execution
- * (each scheduled start/stop date), so a new schedule costs 0.3–0.5 while plain
- * actions stay at 0.1, and `previewRelayFee` quotes the exact fee for the encoded
- * action alongside the worst-case max. The build keeps the combined DeleteFlow (also
- * removes the signer's flow schedule row — see docs/plans/clear-macro-combined-delete.md)
- * and ScheduleFlow's immediate-start mode (startDate 0 + positive rate = create the
- * flow now, schedule only the stop).
- * The same build is deployed on Base mainnet at
- * 0x7043E0B26F221470289d771Ef3139460623D073b (deliberately not wired up in
- * networks.ts until the full production release) — fee token USDCx
- * 0xD04383398dD2426297da660F9CCA3d439AF9ce1b, base fee 0.1, fee receiver the
- * Superfluid DAO Safe 0xac808840f02c47C05507f48165d2222FF28EF4e1; deployed unverified
- * for testing (verify later with `pnpm contracts:deploy --verify base-mainnet`).
- * (It replaced 0xEeFC8492f24898289E65Ee06dE7B8A19F30832a5 — same features at base fee
- * 0.01 charged flat per relayed action — which replaced
- * 0xa35C9faC83e1673e6f1221979e2843Dea4812e78 (immediate-start, no combined DeleteFlow),
- * before that same-code 0x0725db8cf32CDefa1e822CB336ca5caf4cbE69FD paying fees to the
- * deployer, 0x576d1274Ef1E4e1f6093ffC1188c8D32411dDD65, and originally the feeless
- * two-arg 0xa7AA0ff51Bf4a20A1E3516cFEa2C1aD44561a411.)
+ * (regenerate with `pnpm contracts:abi`).
+ *
+ * Deployed and Etherscan-verified on four networks from master 28aa6ab2, all wired up in
+ * networks.ts. Executable bytecode confirmed byte-identical across all four (19,879 bytes;
+ * compare by masking the artifact's `immutableReferences` spans and truncating before the CBOR
+ * metadata block, whose offset is `len(code) - 2 - <the big-endian length in the last 2 bytes>`
+ * — NOT by the trailing metadata hash, which is not reproducible across CI runs, see
+ * docs/plans/clear-macro-multi-network-deploy.md):
+ *
+ *   optimism-sepolia 0x96ec6a06fb72c8C3e42E9DD3ae3525e7847078c3  fee token fUSDCx 0x131780640EDf9830099AAc2203229073d6D2FE69
+ *   base-mainnet     0xC04FE9940e460457B75C3Aa4871bF142E0f49744  fee token USDCx  0xD04383398dD2426297da660F9CCA3d439AF9ce1b
+ *   arbitrum-one     0x3BDd82FFbCcB9DBD0c233Ecd950642edbF60D667  fee token USDCx  0xFc55F2854e74b4f42D01a6d3DAAC4c52D9dfdcFf
+ *   optimism-mainnet 0x4D11B0b59948d81EEAaF667CCDaA212f824949d4  fee token USDCx  0x35Adeb0638EB192755B6E52544650603Fe65A006
+ *
+ * All four are the five-arg fee-charging macro from
+ * contracts/script/DeployDashboardClearMacro.s.sol at base fee 0.1, paying the Superfluid DAO
+ * Safe 0xac808840f02c47C05507f48165d2222FF28EF4e1. NOTE: that Safe has no code yet on
+ * optimism-mainnet, arbitrum-one and optimism-sepolia — fees accrue to it there from the moment
+ * each address is wired up, and are only retrievable once the Safe is deployed at that address on
+ * those chains. Deploying it is an open follow-up.
+ *
+ * Every action AND the fee reads (`previewRelayFee`/`feeToken`/`baseFee`) are live on-chain. Fees
+ * are charged in units of the base fee: 1 per relayed action plus 2 per reserved keeper execution
+ * (each scheduled start/stop date), so a new schedule costs 0.3–0.5 while plain actions stay at
+ * 0.1, and `previewRelayFee` quotes the exact fee for the encoded action alongside the worst-case
+ * max. The build keeps the combined DeleteFlow (also removes the signer's flow schedule row — see
+ * docs/plans/clear-macro-combined-delete.md) and ScheduleFlow's immediate-start mode (startDate 0
+ * + positive rate = create the flow now, schedule only the stop).
+ *
+ * Superseded instances, newest first. The first two are a distinct earlier build (19,852 bytes)
+ * — same features, but not the code above:
+ *   0xEde7e7d71AE56af5CcF8f36952f9bb85FB16fC2d (op-sepolia) paid fees to a fresh empty address,
+ *     0x74cD5673dF7efC148067Ecab494A19a46b0a3167, so arriving fees showed as its whole balance;
+ *   0x7043E0B26F221470289d771Ef3139460623D073b (base) same build, left unverified and never wired
+ *     up — history, not a pending verification task;
+ *   0xEeFC8492f24898289E65Ee06dE7B8A19F30832a5 — same features at base fee 0.01 charged flat per
+ *     relayed action; which replaced
+ *   0xa35C9faC83e1673e6f1221979e2843Dea4812e78 (immediate-start, no combined DeleteFlow);
+ *   0x0725db8cf32CDefa1e822CB336ca5caf4cbE69FD same code, paying fees to the deployer;
+ *   0x576d1274Ef1E4e1f6093ffC1188c8D32411dDD65;
+ *   0xa7AA0ff51Bf4a20A1E3516cFEa2C1aD44561a411 — the original feeless two-arg macro.
  */
 export { dashboardClearMacroAbi } from "./dashboardClearMacroAbi.generated";
 

--- a/src/features/clearMacro/useClearMacroEligibility.ts
+++ b/src/features/clearMacro/useClearMacroEligibility.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { clearMacroForwarderAddress } from "@sfpro/sdk/abi";
 import { useAccount } from "@/hooks/useAccount";
+import config from "@/utils/config";
 import { Network } from "../network/networks";
 import { applySettings } from "../settings/appSettings.slice";
 import { useClearMacroEnabled } from "../settings/appSettingsHooks";
@@ -9,6 +10,11 @@ import { useVisibleAddress } from "../wallet/VisibleAddressContext";
 import { ClearMacroActionKind } from "./dashboardClearMacro";
 
 export function isClearMacroSupportedOnNetwork(network: Network): boolean {
+  // Deployment-wide kill switch (NEXT_PUBLIC_DISABLE_CLEAR_MACRO). Checked here so
+  // every consumer — the UI eligibility hook, the send form's forced-relay scheduling
+  // and allowlist bypass, and the executor gate — goes dark together.
+  if (config.isClearMacroDisabled) return false;
+
   return Boolean(
     network.dashboardClearMacro &&
       clearMacroForwarderAddress[

--- a/src/features/clearMacro/useClearMacroUsdcFeePayment.ts
+++ b/src/features/clearMacro/useClearMacroUsdcFeePayment.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { erc20Abi } from "viem";
 import { useReadContract } from "wagmi";
 import { useAccount } from "@/hooks/useAccount";
+import config from "@/utils/config";
 import { Network } from "../network/networks";
 import { rpcApi, useAppDispatch } from "../redux/store";
 import { applySettings } from "../settings/appSettings.slice";
@@ -28,6 +29,9 @@ export function useRelayCapabilities() {
     queryFn: () => getCapabilities(),
     staleTime: Infinity,
     retry: 1,
+    // Don't probe the relay provider at all when the kill switch is on — it is most
+    // likely flipped precisely because the provider is unhealthy.
+    enabled: !config.isClearMacroDisabled,
   });
 }
 

--- a/src/features/clearMacro/useRelayFee.ts
+++ b/src/features/clearMacro/useRelayFee.ts
@@ -12,6 +12,7 @@ import {
   dashboardClearMacroAbi,
 } from "./dashboardClearMacro";
 import { feeToUnderlyingUnitsCeil } from "./permit2";
+import { isClearMacroSupportedOnNetwork } from "./useClearMacroEligibility";
 
 /** Super Tokens are always 18 decimals, so the fee (in the fee Super Token) formats with 18. */
 const FEE_TOKEN_DECIMALS = 18;
@@ -64,7 +65,11 @@ export function useRelayFeeDisclosure(
   actionKind: ClearMacroActionKind | undefined,
   scheduleAction?: ScheduleFlowQuoteAction
 ): RelayFeeDisclosure {
-  const macroAddress = network.dashboardClearMacro?.macroAddress;
+  // Via the support predicate so the kill switch also stops the macro's fee reads —
+  // with the relay off the quote is never used, and every read below is gated on this.
+  const macroAddress = isClearMacroSupportedOnNetwork(network)
+    ? network.dashboardClearMacro?.macroAddress
+    : undefined;
   const { address } = useAccount();
 
   const { data } = useReadContracts({

--- a/src/features/network/networks.ts
+++ b/src/features/network/networks.ts
@@ -376,6 +376,9 @@ export const networkDefinition = {
     },
     flowSchedulerContractAddress: flowSchedulerContractAddresses.optimism,
     flowSchedulerSubgraphUrl: flowSchedulerSubgraphUrls.optimism,
+    dashboardClearMacro: {
+      macroAddress: "0x4D11B0b59948d81EEAaF667CCDaA212f824949d4",
+    },
     vestingContractAddress: {
       v1: {
         address: vestingContractAddresses_v1.optimism,
@@ -436,6 +439,9 @@ export const networkDefinition = {
     },
     flowSchedulerContractAddress: flowSchedulerContractAddresses.arbitrum,
     flowSchedulerSubgraphUrl: flowSchedulerSubgraphUrls.arbitrum,
+    dashboardClearMacro: {
+      macroAddress: "0x3BDd82FFbCcB9DBD0c233Ecd950642edbF60D667",
+    },
     vestingContractAddress: {
       v1: {
         address: vestingContractAddresses_v1.arbitrum,
@@ -810,6 +816,9 @@ export const networkDefinition = {
     },
     flowSchedulerContractAddress: flowSchedulerContractAddresses.base,
     flowSchedulerSubgraphUrl: flowSchedulerSubgraphUrls.base,
+    dashboardClearMacro: {
+      macroAddress: "0xC04FE9940e460457B75C3Aa4871bF142E0f49744",
+    },
   },
   baseSepolia: {
     ...chain.baseSepolia,
@@ -984,7 +993,7 @@ export const networkDefinition = {
     flowSchedulerContractAddress: flowSchedulerContractAddresses.optimismSepolia,
     flowSchedulerSubgraphUrl: flowSchedulerSubgraphUrls.optimismSepolia,
     dashboardClearMacro: {
-      macroAddress: "0xEde7e7d71AE56af5CcF8f36952f9bb85FB16fC2d",
+      macroAddress: "0x96ec6a06fb72c8C3e42E9DD3ae3525e7847078c3",
     },
   },
 } as const satisfies Record<string, Network>;

--- a/src/features/transactions/useSuperfluidWriteContract.ts
+++ b/src/features/transactions/useSuperfluidWriteContract.ts
@@ -9,7 +9,6 @@ import {
 import * as Sentry from "@sentry/react";
 import { useConfig } from "wagmi";
 import { getPublicClient, simulateContract, writeContract } from "@wagmi/core";
-import { clearMacroForwarderAddress } from "@sfpro/sdk/abi";
 import { TransactionInfo, TransactionTitle } from "@superfluid-finance/sdk-redux";
 import { reduxPersistor, useAppDispatch } from "../redux/store";
 import { useAccount } from "@/hooks/useAccount";
@@ -29,6 +28,7 @@ import {
   useClearMacroPaymentMode,
 } from "../settings/appSettingsHooks";
 import { ClearMacroAction } from "../clearMacro/dashboardClearMacro";
+import { isClearMacroSupportedOnNetwork } from "../clearMacro/useClearMacroEligibility";
 import {
   ClearMacroInsufficientFeeError,
   ClearMacroNotEligibleError,
@@ -233,10 +233,12 @@ export function useSuperfluidWriteContract() {
         isEOA === true &&
         visibleAddress?.toLowerCase() === address.toLowerCase() &&
         !isSmartWallet &&
-        network.dashboardClearMacro &&
-        clearMacroForwarderAddress[
-          params.chainId as keyof typeof clearMacroForwarderAddress
-        ]
+        // Same predicate the UI eligibility hook uses (network is derived from
+        // `params.chainId` above, so this covers the forwarder check too) — it also
+        // carries the NEXT_PUBLIC_DISABLE_CLEAR_MACRO kill switch, so the gate the
+        // user sees and the gate that executes cannot drift.
+        isClearMacroSupportedOnNetwork(network) &&
+        network.dashboardClearMacro
       ) {
         const clearMacroAction = params.clearMacro;
         // Set once the relay accepts the signed payload — from here the execution exists and an

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,6 +57,9 @@ const config = {
   allowlistApiUrl:
     process.env.NEXT_PUBLIC_ALLOWLIST_API ??
     "https://allowlist.superfluid.dev",
+  // Kill switch for the Clear Macro gasless relay. Unset = enabled.
+  isClearMacroDisabled:
+    process.env.NEXT_PUBLIC_DISABLE_CLEAR_MACRO === "true",
 } as const;
 
 export default Object.freeze(config);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,6 @@ export const ACL_DELETE_PERMISSION = 4;
 
 /** Where allowlist-gated features (vesting, stream scheduling, auto-wrap) send users to request access. */
 export const ALLOWLIST_CONTACT_URL = "https://superfluid.org/contact";
+
+/** Public explainer for the Clear Macro relay (clear-signing + gasless fees). */
+export const CLEAR_MACRO_LEARN_MORE_URL = "https://tokens.superfluid.org/clear";


### PR DESCRIPTION
Enables the Clear Macro gasless relay on **Base, Arbitrum One and Optimism mainnet**, hardens the deploy pipeline against the failure modes the first rollout exposed, and links the feature's help tooltip to the public explainer.

## Enabling the relay on mainnet

`DashboardClearMacro` is deployed and Etherscan-verified on four networks, all built from master `28aa6ab2`. Adding each address to `networks.ts` is what turns the relay option on for that network — that is the user-visible change here.

| Network | Macro | Fee token |
|---|---|---|
| optimism-sepolia | `0x96ec6a06fb72c8C3e42E9DD3ae3525e7847078c3` (replaces the previous instance) | fUSDCx |
| base-mainnet | `0xC04FE9940e460457B75C3Aa4871bF142E0f49744` | USDCx |
| arbitrum-one | `0x3BDd82FFbCcB9DBD0c233Ecd950642edbF60D667` | USDCx |
| optimism-mainnet | `0x4D11B0b59948d81EEAaF667CCDaA212f824949d4` | USDCx |

All four are the five-arg fee-charging macro at base fee 0.1, paying the Superfluid DAO Safe `0xac808840f02c47C05507f48165d2222FF28EF4e1`. Executable bytecode is confirmed byte-identical across all four (19,879 bytes) — compared by masking the artifact's `immutableReferences` spans and truncating before the CBOR metadata block, *not* by the trailing metadata hash (see below for why that doesn't work).

The header comment in `dashboardClearMacro.ts` was rewritten to carry this table plus the full list of superseded instances, so the deployment history stays readable from the code.

> [!IMPORTANT]
> **Open follow-up before this is fully production-ready:** the DAO Safe has **no code yet** on optimism-mainnet, arbitrum-one and optimism-sepolia. Fees accrue to that address on those chains from the moment it is wired up, and are only retrievable once the Safe is actually instantiated there. This is not a blocker for merging, but it is a blocker for letting real fee volume build up.

## Deploy pipeline hardening

Each change here was prompted by something that actually went wrong during the first rollout:

- **Deploy and verify are now separate workflow steps**, with verification `continue-on-error`. The base-mainnet run deployed successfully but went red because Etherscan's queue outlasted forge's retry budget. This is a plain `CREATE` deploy with no idempotency check, so a red job that in fact deployed invites a re-dispatch that would silently create a duplicate contract.
- **New verify-only job**, gated on a `run_id` input, that re-verifies a previous run's deployment without redeploying. It resolves that run's `headSha` first, so it recompiles the revision that was actually deployed rather than whatever the current ref is.
- **Verification retry budget raised to ~5 minutes**, and a single verification failure no longer abandons the remaining networks during an `all` run.
- **`auto_detect_remappings = false` and Foundry pinned to v1.7.1.** Builds were not reproducible across CI runs: arbitrum-one got a different metadata hash than the other three despite identical source and byte-identical executable bytecode. Cause: forge auto-discovered 8 extra remappings by walking the nested submodule tree, and those land in compiler metadata without affecting codegen.

`docs/plans/clear-macro-multi-network-deploy.md` carries the detail and the retrospective.

## "Learn more" link in the gasless tooltip

The relay strip's help tooltips ended on a bare "Powered by Clear Macro." — a product name with nowhere to look it up. That attribution now links to <https://tokens.superfluid.org/clear>, which explains both halves of what the tooltip alludes to: clear-signing of human-readable transactions, and paying fees without ETH.

- The main tooltip's title becomes JSX to carry the link (the copy itself is unchanged apart from the moved attribution).
- The smart-contract-wallet "not available" tooltip gains the attribution it never had.
- Both get a longer `leaveTouchDelay` so touch users can reach the link before it dismisses. Neither may take `disableInteractive`, or the link becomes unhoverable — there's a comment on the shared element saying so.
- New `CLEAR_MACRO_LEARN_MORE_URL` in `src/utils/constants.ts`, alongside the existing `ALLOWLIST_CONTACT_URL`.

This is the app's first user-facing external Superfluid link, so it also sets the pattern.

## Testing

- `pnpm typecheck` and `pnpm lint` pass.
- Contract deployments verified on-chain and on Etherscan; bytecode equivalence checked as described above.
- **Not yet verified in a browser:** the tooltip link's hover/touch behaviour on a live Clear Macro network. Worth a manual check on the Send Stream form — confirm the pointer can travel from the info icon into the tooltip without it closing.
- No Cypress spec asserts this tooltip's text; `data-cy="clear-macro-learn-more-link"` is left as a hook if one is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
