### PR TITLE
chore(network): Remove discontinued Scroll Sepolia (534351)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "62.0.0",
+  "version": "63.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/network/networkConstants.ts
+++ b/src/features/network/networkConstants.ts
@@ -12,7 +12,6 @@ export const chainIds = {
   base: 8453,
   baseSepolia: 84532,
   scroll: 534352,
-  scrollSepolia: 534351,
   optimismSepolia: 11155420,
   degen: 666666666,
 } as const;
@@ -158,7 +157,6 @@ export const superfluidRpcUrls = {
   base: "https://rpc-endpoints.superfluid.dev/base-mainnet",
   "base-sepolia": "https://rpc-endpoints.superfluid.dev/base-sepolia",
   scroll: "https://rpc-endpoints.superfluid.dev/scroll-mainnet",
-  "scroll-sepolia": "https://rpc-endpoints.superfluid.dev/scroll-sepolia",
   "optimism-sepolia": "https://rpc-endpoints.superfluid.dev/optimism-sepolia",
 } as const;
 

--- a/src/features/network/networks.ts
+++ b/src/features/network/networks.ts
@@ -912,42 +912,6 @@ export const networkDefinition = {
     vestingSubgraphUrl: undefined,
     autoWrapSubgraphUrl: undefined,
   },
-  scrollSepolia: {
-    ...chain.scrollSepolia,
-    supportsGDA: getSupportsGDA(chainIds.scrollSepolia),
-    metadata: ensureDefined(
-      sfMeta.getNetworkByChainId(chainIds.scrollSepolia),
-      chainIds.scrollSepolia
-    ),
-    blockExplorers: ensureDefined(chain.scrollSepolia.blockExplorers),
-    slugName: "scrsepolia",
-    v1ShortName: "scrsepolia",
-    bufferTimeInMinutes: 60,
-    color: "#EECDA6",
-    rpcUrls: {
-      ...chain.scrollSepolia.rpcUrls,
-      superfluid: { http: [superfluidRpcUrls["scroll-sepolia"]] },
-    },
-    getLinkForTransaction: (txHash: string): string =>
-      `https://sepolia.scrollscan.com/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://sepolia.scrollscan.com/address/${address}`,
-    nativeCurrency: {
-      ...ensureDefined(chain.scrollSepolia.nativeCurrency),
-      address: NATIVE_ASSET_ADDRESS,
-      type: TokenType.NativeAssetUnderlyingToken,
-      superToken: ensureDefined(findNativeAssetSuperTokenFromTokenList({ chainId: chain.scrollSepolia.id, address: "0x58f0A7c6c143074f5D824c2f27a85f6dA311A6FB" })),
-      logoURI: "https://tokenlist.superfluid.org/icons/eth.svg",
-      isSuperToken: false,
-    },
-    vestingContractAddress: {
-      v1: undefined,
-      v2: undefined,
-      v3: undefined,
-    },
-    vestingSubgraphUrl: undefined,
-    autoWrapSubgraphUrl: undefined,
-  },
   optimismSepolia: {
     ...chain.optimismSepolia,
     supportsGDA: getSupportsGDA(chainIds.optimismSepolia),
@@ -1030,7 +994,6 @@ export const allNetworks: [Network, ...Network[]] = orderBy(
       networkDefinition.base,
       networkDefinition.baseSepolia,
       networkDefinition.scroll,
-      networkDefinition.scrollSepolia,
       networkDefinition.degenChain,
     ],
     (x) => x.id // Put lower ids first (Ethereum mainnet will be first)
@@ -1108,4 +1071,5 @@ export const deprecatedNetworkChainIds = [
   421613, // Arbitrum Goerli
   1442, // Polygon zkEVM Testnet
   84531, // Base Goerli
+  534351, // Scroll Sepolia
 ];

--- a/src/features/network/networks.ts
+++ b/src/features/network/networks.ts
@@ -2,7 +2,7 @@ import { isString, orderBy } from "lodash";
 import memoize from "lodash/memoize";
 import * as chain from "wagmi/chains";
 import { Chain } from "wagmi/chains";
-import ensureDefined from "../../utils/ensureDefined";
+import ensureDefined, { isDefined } from "../../utils/ensureDefined";
 import {
   NATIVE_ASSET_ADDRESS,
   NativeAsset,
@@ -1073,3 +1073,57 @@ export const deprecatedNetworkChainIds = [
   84531, // Base Goerli
   534351, // Scroll Sepolia
 ];
+
+/**
+ * Networks present in `@superfluid-finance/metadata` that the Dashboard intentionally does not
+ * support. Every entry needs a reason. This exists so that the completeness check below can stay
+ * strict: an *accidental* omission still fails loudly, while a deliberate one is documented here.
+ *
+ * Note we cannot derive this from metadata's own `isDeprecated` flag -- Scroll Sepolia is not
+ * flagged there.
+ */
+const metadataNetworkExclusions = new Map<number, string>([
+  [
+    534351,
+    "Scroll Sepolia is discontinued, and its canonical Superfluid subgraph alias was serving Optimism Sepolia data (reported upstream).",
+  ],
+]);
+
+// Fail loudly if metadata gains a network nobody added here (or if an exclusion becomes obsolete).
+// Both sides of this comparison are fixed at build time, so a violation surfaces during `next build`
+// / SSR rather than in a user's browser -- hence the console.error rather than a throw on the client.
+{
+  const unaccounted = sfMeta.networks
+    .filter(
+      ({ chainId }) =>
+        !allNetworks.some((network) => network.id === chainId) &&
+        !metadataNetworkExclusions.has(chainId)
+    )
+    .map(({ chainId, name }) => `${name} (${chainId})`);
+
+  const staleExclusions = [...metadataNetworkExclusions.keys()].filter(
+    (chainId) => !sfMeta.networks.some((network) => network.chainId === chainId)
+  );
+
+  const problems = [
+    unaccounted.length
+      ? `Superfluid metadata networks not supported by the Dashboard and not explicitly excluded: ${unaccounted.join(
+          ", "
+        )}. Add them to \`allNetworks\`, or to \`metadataNetworkExclusions\` with a reason.`
+      : undefined,
+    staleExclusions.length
+      ? `\`metadataNetworkExclusions\` lists chain ids no longer present in Superfluid metadata: ${staleExclusions.join(
+          ", "
+        )}. Drop them.`
+      : undefined,
+  ].filter(isDefined);
+
+  if (problems.length) {
+    const message = problems.join(" ");
+    if (typeof window === "undefined") {
+      throw new Error(message);
+    } else {
+      console.error(message);
+    }
+  }
+}

--- a/src/features/redux/store.ts
+++ b/src/features/redux/store.ts
@@ -103,11 +103,17 @@ export const subgraphApi = initializeSubgraphApiSlice((options) =>
 
 export const transactionTracker = initializeTransactionTrackerSlice();
 
+// NOTE: redux-persist passes the *target* version from this config as `migrate`'s second
+// argument -- not the version the persisted state was written at. The previous `currentVersion === 1`
+// guards were therefore dead code once these slices moved past version 1, which meant entities
+// belonging to removed networks were never actually purged. These sanitizers now run on every
+// rehydrate instead; they are idempotent, so that is safe and keeps working for future removals.
 const transactionTrackerPersistedReducer = persistReducer(
-  { storage, key: "transactions", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
+  { storage, key: "transactions", version: 2, migrate: async (persistedState) => {
+    if (persistedState) {
       const oldState = persistedState as PersistedState & EntityState<TrackedTransaction, string>;
       const transactionsToRemove = Object.values(oldState.entities).filter(isDefined).filter(x => deprecatedNetworkChainIds.includes(x.chainId)) as TrackedTransaction[];
+      if (!transactionsToRemove.length) return persistedState;
       const newEntities = { ...oldState.entities };
       for (const tx of transactionsToRemove) {
         delete newEntities[tx.hash];
@@ -129,8 +135,8 @@ const impersonationPersistedReducer = persistReducer(
 );
 
 const addressBookPersistedReducer = persistReducer(
-  { storage, key: "addressBook", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
+  { storage, key: "addressBook", version: 2, migrate: async (persistedState) => {
+    if (persistedState) {
       const oldState = persistedState as PersistedState & AddressBookState;
       const newEntities = { ...oldState.entities };
       Object.values(newEntities).filter(isDefined).forEach((x) => {
@@ -149,13 +155,14 @@ const addressBookPersistedReducer = persistReducer(
 );
 
 const customTokensPersistedReducer = persistReducer(
-  { storage, key: "customTokens", version: 2, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
+  { storage, key: "customTokens", version: 2, migrate: async (persistedState) => {
+    if (persistedState) {
       const oldState = persistedState as PersistedState & NetworkCustomTokenState;
       const newEntities = { ...oldState.entities };
       Object.values(newEntities).forEach((x) => {
         if (x && deprecatedNetworkChainIds.includes(x.chainId)) {
-          delete newEntities[x.customToken];
+          // Entities are keyed by `${chainId}-${address}`, not by the bare address.
+          delete newEntities[getCustomTokenId(x.chainId, x.customToken)];
         }
       });
       return {
@@ -170,8 +177,8 @@ const customTokensPersistedReducer = persistReducer(
 );
 
 const networkPreferencesPersistedReducer = persistReducer(
-  { storage, key: "networkPreferences", version: 3, migrate: async (persistedState, currentVersion) => {
-    if (persistedState && currentVersion === 1) {
+  { storage, key: "networkPreferences", version: 3, migrate: async (persistedState) => {
+    if (persistedState) {
       const oldState = persistedState as PersistedState & NetworkPreferencesState;
       const newEntities = { ...oldState.entities };
       Object.values(newEntities).forEach((x) => {
@@ -184,8 +191,9 @@ const networkPreferencesPersistedReducer = persistReducer(
         entities: newEntities
       }
     }
-
-    // TODO: migrate?
+    // Must return the state: falling through to `undefined` here made rehydration
+    // discard the user's persisted network preferences on every load.
+    return persistedState;
   } },
   networkPreferencesSlice.reducer
 );

--- a/tests/cypress/fixtures/nativeTokenBalances.json
+++ b/tests/cypress/fixtures/nativeTokenBalances.json
@@ -66,12 +66,6 @@
         "superTokenBalance": "0"
       }
     },
-    "scrsepolia": {
-      "ETH": {
-        "underlyingBalance": "0",
-        "superTokenBalance": "0"
-      }
-    },
     "scroll": {
       "ETH": {
         "underlyingBalance": "0",

--- a/tests/cypress/fixtures/rejectedCaseTokens.json
+++ b/tests/cypress/fixtures/rejectedCaseTokens.json
@@ -66,11 +66,6 @@
     "TokenTwo": "fUSDC",
     "TokenGas": "ETH"
   },
-  "scrsepolia": {
-    "TokenOne": "fDAI",
-    "TokenTwo": "fUSDC",
-    "TokenGas": "ETH"
-  },
   "opsepolia": {
     "TokenOne": "fDAI",
     "TokenTwo": "fUSDC",

--- a/tests/cypress/pageObjects/pages/SendPage.ts
+++ b/tests/cypress/pageObjects/pages/SendPage.ts
@@ -686,7 +686,6 @@ export class SendPage extends BasePage {
         'sepolia',
         'base',
         'scroll',
-        'scrsepolia',
         'opsepolia',
       ].includes(Cypress.env('network')) &&
       Cypress.env('platformNeeded')
@@ -707,7 +706,6 @@ export class SendPage extends BasePage {
         'sepolia',
         'base',
         'scroll',
-        'scrsepolia',
         'opsepolia',
         'degen',
       ].includes(Cypress.env('network')) &&

--- a/tests/cypress/superData/networks.ts
+++ b/tests/cypress/superData/networks.ts
@@ -106,7 +106,6 @@ export const superfluidRpcUrls = {
   sepolia: 'https://rpc-endpoints.superfluid.dev/eth-sepolia',
   base: 'https://rpc-endpoints.superfluid.dev/base-mainnet',
   scroll: 'https://rpc-endpoints.superfluid.dev/scroll-mainnet',
-  'scroll-sepolia': 'https://rpc-endpoints.superfluid.dev/scroll-sepolia',
   'optimism-sepolia': 'https://rpc-endpoints.superfluid.dev/optimism-sepolia',
   degenChain: 'https://rpc-endpoints.superfluid.dev/degenchain',
 };
@@ -124,7 +123,6 @@ export const networkDefinition: {
   sepolia: Network;
   base: Network;
   scroll: Network;
-  scrollSepolia: Network;
   optimismSepolia: Network;
   degenChain: Network;
 } = {
@@ -517,34 +515,6 @@ export const networkDefinition: {
       },
     },
   },
-  scrollSepolia: {
-    id: 534351,
-    name: 'Scroll Sepolia',
-    network: 'scroll-sepolia',
-    slugName: 'scrsepolia',
-    v1ShortName: 'scrsepolia',
-    testnet: true,
-    bufferTimeInMinutes: 60,
-    color: '#FFDBB0',
-    superfluidRpcUrl: superfluidRpcUrls['scroll-sepolia'],
-    subgraphUrl: 'https://scroll-sepolia.subgraph.x.superfluid.dev/',
-    getLinkForTransaction: (txHash: string): string =>
-      `https://sepolia.scrollscan.com/tx/${txHash}`,
-    getLinkForAddress: (address: string): string =>
-      `https://sepolia.scrollscan.com/tx/address/${address}`,
-    nativeCurrency: {
-      ...ensureDefined(chain.scrollSepolia.nativeCurrency),
-      address: NATIVE_ASSET_ADDRESS,
-      type: TokenType.NativeAssetUnderlyingToken,
-      superToken: {
-        type: TokenType.NativeAssetSuperToken,
-        symbol: 'ETHx',
-        address: '0x58f0A7c6c143074f5D824c2f27a85f6dA311A6FB',
-        name: 'Super ETH',
-        decimals: 18,
-      },
-    },
-  },
   optimismSepolia: {
     id: 11155420,
     name: 'OP Sepolia',
@@ -628,7 +598,6 @@ export const networks: Network[] = [
   networkDefinition.sepolia,
   networkDefinition.base,
   networkDefinition.scroll,
-  networkDefinition.scrollSepolia,
   networkDefinition.optimismSepolia,
   networkDefinition.degenChain,
 ];

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -31,7 +31,8 @@ Cypress.on("uncaught:exception", (err, runnable) => {
     err.message.includes(
       "Request failed with status code 429 Too Many Requests"
     ) ||
-    //An error popping up on scroll sepolia , cannot reproduce manually
+    //Was originally only seen on scroll-sepolia (now removed), cannot reproduce manually.
+    //Kept until an hourly full-suite run confirms no other network hits it.
     err.message.includes("getInitialProps") ||
     //Error popping up when loading gnosis safe custom apps page
     err.message.includes("Minified React error #418") ||

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -31,9 +31,6 @@ Cypress.on("uncaught:exception", (err, runnable) => {
     err.message.includes(
       "Request failed with status code 429 Too Many Requests"
     ) ||
-    //Was originally only seen on scroll-sepolia (now removed), cannot reproduce manually.
-    //Kept until an hourly full-suite run confirms no other network hits it.
-    err.message.includes("getInitialProps") ||
     //Error popping up when loading gnosis safe custom apps page
     err.message.includes("Minified React error #418") ||
     err.message.includes("Minified React error #423") ||

--- a/tests/cypress/support/walletSetup.js
+++ b/tests/cypress/support/walletSetup.js
@@ -1014,7 +1014,6 @@ const networkGasTokenSymbols = {
   421613: 'ETHx',
   11155111: 'ETHx',
   11155420: 'ETHx',
-  534351: 'ETHx',
   8453: 'ETHx',
 };
 


### PR DESCRIPTION
Removes the Scroll Sepolia network (chainId 534351) from the Dashboard. Scroll mainnet (534352) is untouched.

Two independent reasons: Scroll Sepolia is being discontinued, and its canonical Superfluid subgraph alias was found to be serving **Optimism Sepolia** data — the endpoint reported head block `46674627`, which does not exist on Scroll Sepolia (chain head ~19.0M) and matches Optimism Sepolia's block hash exactly. Reported upstream.

The network appeared under four spellings (`scroll-sepolia`, `scrollSepolia`, `534351`, and the short slug `scrsepolia`), so removal spans the network definitions, the Cypress `superData` mirror, the platform-skip lists, two fixtures, and the wallet-setup map.

### The second commit is the one worth reviewing

While tracing what happens to persisted Redux state referencing a removed chain, the removal turned out to expose a latent crash — and the mitigation I first reached for was inert.

**redux-persist migrations were dead code.** redux-persist passes the *target* version from the persist config as `migrate`'s second argument, not the version the persisted state was written at (`persistReducer.js`: `var version = config.version` → `migrate(restoredState, version)`). The `currentVersion === 1` guards therefore stopped running the moment those slices moved past v1 — they are at 2/2/2/3. Entities belonging to removed networks have never actually been purged, for any of the six previously removed networks either.

That matters here: a persisted transaction on a removed chain stays visible, and restoring it calls `setExpectedNetwork(534351)` → `findNetworkOrThrow`, which throws (`restore-transaction.tsx:27` → `ExpectedNetworkContext.tsx:54`). The sanitizers are now unconditional. They are idempotent and `migrate` already runs on every rehydrate, so this needs no version bump — the lower-risk option.

Two pre-existing bugs inside those same functions had to be fixed for the purge to work at all:

- **customTokens deleted by the wrong key** — it deleted by the bare address, but the entity adapter keys by `getCustomTokenId(chainId, customToken)` → `${chainId}-${address}`. It never deleted anything.
- **networkPreferences returned `undefined`** — it fell through past the dead branch with no return, so rehydration discarded the user's persisted network preferences on *every load*.

### Metadata completeness guard

The Dashboard supports every network in `@superfluid-finance/metadata` except this one (15 of 16), so `metadataNetworkExclusions` is a single documented entry rather than an unwieldy list. Metadata does not flag 534351 as deprecated, so this cannot be derived automatically.

The check fails on an unaccounted metadata network *and* on a stale exclusion, so it cannot rot. It throws server-side and logs in the browser: both sides are fixed at build time, so a violation always surfaces during `next build` rather than as a white screen for users.

Verified by deleting the exclusion and rebuilding — the build fails with the intended error. Also confirmed it catches a simulated accidental omission (dropping Base) and a stale exclusion, and is silent when correct.

### Also

Removed the obsolete `getInitialProps` Cypress exception suppression. Its only documented cause was Scroll Sepolia, and keeping it pending a confirming run was circular — the suppression is what prevents any run from surfacing it.

### Verification

`pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass. The Cypress `tsc` project reports no errors in repo sources (its only errors are pre-existing typings under `node_modules/ox`). The full Cypress suite was deliberately not run.

Left alone: Scroll mainnet including the shared `scroll.svg` icon, and the `docs/plans/` Phase 4 section, which is a historical record of the June work that dropped `scrsepolia` from CI rows.