### PR TITLE
fix(tests): Align stream-scheduling e2e with the Clear Macro relay

### DIFF
--- a/tests/cypress/integration/RejectedStreamAndIndexTransactions.feature
+++ b/tests/cypress/integration/RejectedStreamAndIndexTransactions.feature
@@ -86,7 +86,7 @@ Feature: Transactional rejected test cases
     And Distribution revoking dialog on "selected network" shows up
     And Transaction rejected error is shown
 
-  @platformNeeded
+  @platformNeeded @gaslessRelayEnabled
   Scenario: Creating a stream with just start date
     Given The test case is skipped if the platform is not deployed on the network
 
@@ -100,7 +100,7 @@ Feature: Transactional rejected test cases
     And Scheduled stream transaction dialogs are shown
     And Transaction rejected error is shown
 
-  @platformNeeded
+  @platformNeeded @gaslessRelayEnabled
   Scenario: Creating a stream with just end date
     Given The test case is skipped if the platform is not deployed on the network
 
@@ -114,7 +114,7 @@ Feature: Transactional rejected test cases
     And Scheduled stream transaction dialogs are shown
     And Transaction rejected error is shown
 
-  @platformNeeded
+  @platformNeeded @gaslessRelayEnabled
   Scenario: Creating a stream with start and end date
     Given The test case is skipped if the platform is not deployed on the network
 

--- a/tests/cypress/integration/SendPage.feature
+++ b/tests/cypress/integration/SendPage.feature
@@ -136,10 +136,15 @@ Feature: Send Page test cases
     And User inputs a date "1" "month" into the future into the stream end date
     Then The total stream amount is correctly calculated to be "1"
 
-  Scenario: Scheduled streams - Allowlist message
+  # The Clear Macro relay fee replaces the platform allowlist for eligible signers, and every
+  # network that supports scheduling is a Clear Macro network -- so an eligible EOA no longer sees
+  # the allowlist overlay on any scheduling network. This scenario asserted the opposite before
+  # the relay landed; the overlay itself still covers non-eligible signers (see SendStream.tsx).
+  Scenario: Scheduled streams - Allowlist is bypassed on Clear Macro networks
     Given "Send Page" is open with "alice" connected on "polygon"
     And User clicks the scheduling toggle
-    Then Allowlist message is shown
+    Then Allowlist message is not shown
+    And Scheduled stream fields are visible
 
   Scenario: Scheduled streams - Allowlist not needed on opsepolia
     Given "Send Page" is open with "alice" connected on "opsepolia"
@@ -173,6 +178,7 @@ Feature: Send Page test cases
     And User opens "opsepolia" "fTUSDx" individual token page
     Then The stream row to "0x9B6157d44134b21D934468B8bf709294cB298aa7" has a flow rate of "-1" and dates to "5 Mar. 2025 12:1031 Dec. 2026 23:00"
 
+  @gaslessRelayEnabled
   Scenario: Modifying a streams start date
     Given HDWallet transactions are rejected
 
@@ -186,7 +192,7 @@ Feature: Send Page test cases
     And Scheduled stream transaction dialogs are shown
     And Transaction rejected error is shown
 
-  @checkEndDate
+  @checkEndDate @gaslessRelayEnabled
   Scenario: Modifying a stream with just end date
     Given HDWallet transactions are rejected
 
@@ -202,7 +208,7 @@ Feature: Send Page test cases
     And Scheduled stream transaction dialogs are shown
     And Transaction rejected error is shown
 
-  @checkEndDate
+  @checkEndDate @gaslessRelayEnabled
   Scenario: Modifying a stream with start and end date ( not started yet )
     Given HDWallet transactions are rejected
 

--- a/tests/cypress/pageObjects/pages/Common.ts
+++ b/tests/cypress/pageObjects/pages/Common.ts
@@ -276,6 +276,16 @@ export class Common extends BasePage {
 
     cy.visit(page, {
       onBeforeLoad: (window) => {
+        // Seeded here rather than in a Before hook so it lands in the application window
+        // before redux-persist rehydrates. See the @gaslessRelayEnabled hook for why.
+        if (Cypress.env('gaslessRelayEnabled')) {
+          window.localStorage.setItem(
+            'persist:appSettings',
+            // redux-persist stores each field JSON-stringified and merges over `initialState`,
+            // so only the field under test has to be present here.
+            '{"clearMacroEnabled":"true","_persist":"{\\"version\\":1,\\"rehydrated\\":true}"}'
+          );
+        }
         try {
           const normalizedKey = (
             usedAccountPrivateKey.startsWith('0x')

--- a/tests/cypress/pageObjects/pages/SendPage.ts
+++ b/tests/cypress/pageObjects/pages/SendPage.ts
@@ -623,6 +623,10 @@ export class SendPage extends BasePage {
     this.hasCSS(START_DATE_BORDER, 'border-color', 'rgb(210, 37, 37)');
   }
 
+  // Kept for the signers who can still hit the overlay -- it is bypassed only for eligible
+  // Clear Macro signers, so a non-eligible one (view mode, smart-contract wallet) still sees it.
+  // No scenario exercises that path today; adding one needs a view-mode step that can pick the
+  // network, which does not exist yet.
   static validateVisibleAllowlistMessage() {
     this.isVisible(ALLOWLIST_MESSAGE);
     this.containsText(ALLOWLIST_MESSAGE, 'You are not on the allow list.');
@@ -636,6 +640,11 @@ export class SendPage extends BasePage {
       'href',
       'https://superfluid.org/contact'
     );
+  }
+
+  static validateAllowlistMessageIsNotShown() {
+    this.doesNotExist(ALLOWLIST_MESSAGE);
+    this.doesNotExist(ALLOWLIST_LINK);
   }
 
   static validateScheduledStreamFieldsAreVisible() {

--- a/tests/cypress/support/step_definitions/Hooks.ts
+++ b/tests/cypress/support/step_definitions/Hooks.ts
@@ -7,6 +7,11 @@ Before(() => {
     "customTokens",
     `{"56":"0x1E38baa2735128Bcc23792fF9AaE96EA7aA7ecd2,0x0419e1fA3671754F77EC7D5416219A5f9A08B530"}`
   );
+  // Cleared here rather than in an After hook: After does not run when a scenario fails (see the
+  // @rejected note below), and a leaked flag would silently route later scenarios through the
+  // relay. Hooks run in definition order, so the @gaslessRelayEnabled hook re-enables it after
+  // this reset for the scenarios that want it.
+  Cypress.env("gaslessRelayEnabled", false);
 });
 
 Before({ tags: "@rejected" }, function () {
@@ -19,6 +24,19 @@ Before({ tags: "@rejected" }, function () {
 
 Before({ tags: "@platformNeeded" }, () => {
   Cypress.env("platformNeeded", true);
+});
+
+// Scheduling a stream on a Clear Macro network is forced through the gasless relay: the send form
+// keeps submit disabled until the relay toggle is on (`isSchedulerRelayForced` in SendStream.tsx).
+// Every network that supports scheduling is a Clear Macro network, so seed the persisted preference
+// before the app boots -- otherwise these scenarios would only ever assert the relay opt-in gate
+// instead of the scheduling flow they are actually about.
+// The preference itself is written in `Common.openDashboardWithConnectedTxAccount`'s
+// `onBeforeLoad`, so it lands in the application window before redux-persist rehydrates --
+// a Before hook here would only reach the spec window.
+Before({ tags: "@gaslessRelayEnabled" }, () => {
+  cy.log("Clear Macro gasless relay will be enabled ✅");
+  Cypress.env("gaslessRelayEnabled", true);
 });
 
 // Alias the vesting-scheduler detail query before the schedule details page loads, so the

--- a/tests/cypress/support/step_definitions/SendPageSteps.ts
+++ b/tests/cypress/support/step_definitions/SendPageSteps.ts
@@ -259,6 +259,11 @@ Then(/^Allowlist message is shown$/, function () {
     SendPage.validateVisibleAllowlistMessage()
   );
 });
+Then(/^Allowlist message is not shown$/, function () {
+  SendPage.runFunctionIfPlatformIsDeployedOnNetwork(() =>
+    SendPage.validateAllowlistMessageIsNotShown()
+  );
+});
 Then(/^Scheduled stream fields are visible$/, function () {
   SendPage.runFunctionIfPlatformIsDeployedOnNetwork(() =>
     SendPage.validateScheduledStreamFieldsAreVisible()


### PR DESCRIPTION
Stream scheduling moved behind the Clear Macro gasless relay in #873–#875, but the Cypress scenarios still encode the pre-relay behaviour. They have been failing on every preview run since — the failures rotate across shards and networks, which made them look like the suite's known flake rather than a real signal.

The correlation is exact: every network whose `rejected-tests` job fails has the relay configured, and the only two that never fail (`avalanche-fuji`, `sepolia`) are the two non-relay networks in the matrix.

There are two distinct causes, both in `SendStream.tsx`.

### 1. Submit is gated on the relay toggle

`isSchedulerRelayForced` (line 589) keeps submit disabled until the relay toggle is on, and `clearMacroEnabled` defaults to `false`. The create/modify scheduling scenarios therefore timed out waiting on the submit button — the `expected '<button.MuiButtonBase-root…>'` signature.

Added a `@gaslessRelayEnabled` tag that seeds the persisted preference, so these scenarios exercise scheduling rather than the relay opt-in gate.

Two implementation details worth reviewing:

- The value is written in `Common.openDashboardWithConnectedTxAccount`'s `onBeforeLoad` rather than in the `Before` hook, so it lands in the **application** window before redux-persist rehydrates. A `Before` hook only reaches the spec window.
- The flag is reset in the **global `Before` hook**, not an `After` hook — `After` does not run when a scenario fails (the existing `@rejected` comment says as much), and a leaked flag would silently route later scenarios through the relay.

### 2. The allowlist overlay is gone on relay networks

`isAllowlistBypassed` (line 845) means the relay fee replaces the platform allowlist for eligible signers. Every network that supports scheduling is also a Clear Macro network — I verified both sets are identical (`gnosis, polygon, optimism, arbitrum, avalancheC, bsc, ethereum, base, optimismSepolia`) — so an eligible EOA can no longer see the overlay on any scheduling network at all.

`Scheduled streams - Allowlist message` asserted the overlay **is** shown, on polygon. It now asserts the bypass instead. This is a confirmed permanent behaviour change, not a regression.

`validateVisibleAllowlistMessage` is deliberately kept rather than deleted: the overlay still covers non-eligible signers (view mode, smart-contract wallets). No scenario exercises that path today because the view-mode step cannot select a network, so I left it as a documented follow-up instead of adding a scenario I could not verify.

### Verification

The tests-package typecheck is clean — its only errors are the pre-existing unresolved `@superfluid-finance/metadata` import in files this PR does not touch. The scenarios themselves can only be verified by a preview CI run, which is what this PR is for.

Two things I could not settle locally and would like confirmed by the run: that the seeded `persist:appSettings` value is picked up as intended, and that no scenario outside the tagged set depended on the relay being off.

Refs #877 — that PR surfaced these failures but does not cause them; they are unrelated to it.