### PR TITLE
fix(analytics): stop the disabled Segment integration from booting

### DIFF
--- a/src/features/analytics/AnalyticsProvider.tsx
+++ b/src/features/analytics/AnalyticsProvider.tsx
@@ -1,46 +1,57 @@
-import { AnalyticsBrowser } from "@segment/analytics-next";
+import type { AnalyticsBrowser } from "@segment/analytics-next";
 import { createContext, useMemo } from "react";
-import config from "../../utils/config";
-import { IsCypress } from "../../utils/SSRUtils";
 import { AppInstanceDetails, useAppInstanceDetails } from "./useAppInstanceDetails";
 
 type AnalyticsProviderProps = {
   children: React.ReactNode;
 };
 
+/**
+ * The subset of `AnalyticsBrowser` this app actually consumes. Argument types are
+ * derived from the real library types so call sites stay just as strictly checked,
+ * while the return type is widened to `Promise<unknown>` so that both the no-op stub
+ * below and a genuine `AnalyticsBrowser` are assignable.
+ */
+export type AnalyticsInterface = {
+  [K in "track" | "identify" | "page" | "reset"]: (
+    ...args: Parameters<AnalyticsBrowser[K]>
+  ) => Promise<unknown>;
+};
+
 type AnalyticsContextValue = {
-  analyticsBrowser: AnalyticsBrowser;
+  analyticsBrowser: AnalyticsInterface;
   instanceDetails: AppInstanceDetails;
 };
 
 export const AnalyticsContext = createContext<AnalyticsContextValue>(undefined!);
 
-const useAnalyticsBrowser = () =>
-  useMemo(() => {
-    const writeKey: string | undefined = undefined; // Tracking disabled: force no-op Segment instance.
-    if (!IsCypress && writeKey) {
-      return AnalyticsBrowser.load(
-        { writeKey },
-        {
-          initialPageview: true,
-        }
-      );
-    } else {
-      // Tracking is intentionally disabled; provide a no-op Segment instance.
-      return AnalyticsBrowser.load({ writeKey: "NOOP" });
-    }
-  }, []);
+/**
+ * Tracking is intentionally disabled (see #864). This is a genuine no-op: importing
+ * `AnalyticsBrowser` as a type only keeps the Segment library out of the bundle, so
+ * nothing loads Segment settings from the CDN. Constructing an `AnalyticsBrowser`
+ * without calling `load()` would also avoid the network request, but it buffers every
+ * call forever and returns promises that never settle.
+ *
+ * To re-enable tracking, replace this with
+ * `AnalyticsBrowser.load({ writeKey: config.segmentWriteKey }, { initialPageview: true })`
+ * (restoring the runtime import).
+ */
+const noopAnalyticsBrowser: AnalyticsInterface = Object.freeze({
+  track: () => Promise.resolve(),
+  identify: () => Promise.resolve(),
+  page: () => Promise.resolve(),
+  reset: () => Promise.resolve(),
+});
 
 export const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => {
-  const analyticsBrowser = useAnalyticsBrowser();
   const instanceDetails = useAppInstanceDetails();
 
   const contextValue = useMemo(
     () => ({
-      analyticsBrowser,
+      analyticsBrowser: noopAnalyticsBrowser,
       instanceDetails,
     }),
-    [analyticsBrowser, instanceDetails]
+    [instanceDetails]
   );
 
   return (


### PR DESCRIPTION
## The problem

One Sentry issue is **91.5% of this app's error volume**: `Cannot GET - Invalid path or write key provided.` — **163,930 events, 402 users**, first seen **2025-05-12**, still firing at a flat ~1,030/day ([`SUPERFLUID-DASHBOARD-DXR`](https://superfluid-finance.sentry.io/issues/?query=is%3Aunresolved)).

It is not a stale or wrong write key. `AnalyticsProvider.tsx` disabled tracking by hardcoding `writeKey = undefined`, then fell into an `else` branch that **still called** `AnalyticsBrowser.load({ writeKey: "NOOP" })`. Segment dutifully requested settings for a project literally named `NOOP` and returned that error. A disabled integration that still boots.

The `"NOOP"` fallback dates to #308 (2023) and was harmless while `config.segmentWriteKey` was populated — that requires `NETLIFY_CONTEXT`/`VERCEL_ENV === "production"`. The Sentry first-seen date is a year *before* #864 deliberately disabled tracking, so production had already stopped meeting that condition, most likely at a hosting move. #864 then made it unconditional.

## The fix

One file, +34/−23.

- `AnalyticsBrowser.load({ writeKey: "NOOP" })` is gone; `analyticsBrowser` is a module-level frozen stub whose four methods return `Promise.resolve()`. Module-level means stable function identities, so the `useCallback`/`useEffect` dependency arrays in `MonitorContext.tsx` and `useAnalytics.tsx` behave exactly as before.
- A new `AnalyticsInterface` type derives its **argument** types from the real library types, so every call site stays as strictly checked as before. The return type is widened to `Promise<unknown>` so a genuine `AnalyticsBrowser` stays assignable — re-enabling tracking is a one-line swap back, documented at the stub.
- The Segment import is now **type-only**, so `@segment/analytics-next` leaves the client bundle entirely.

`useAnalytics.tsx` and all ~20 `txAnalytics` call sites are untouched.

### Why not "an `AnalyticsBrowser` that is never `load()`ed"

That was the first candidate and it is factually correct — an unloaded instance issues no network request. It was rejected because every buffered method returns a promise that **never settles** while the instance is unset, retaining its serialized args for the lifetime of the tab. `page()` fires on every route change and `track()` on every transaction status change, so it grows unbounded. Not a regression (today's `"NOOP"` load buffers identically) but not worth preserving.

## Behaviour delta

`track`/`page`/`reset`/`identify` still return promises and still do nothing observable. The single difference is that they now *resolve*, so `MonitorContext.tsx:93`'s `track(...).then(() => identify(wallet))` runs its callback — which calls another no-op. Previously it never ran. No other consumer inspects a return value.

Net: the only thing lost is a network request that was already failing.

## Verification

- `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm build` — all clean.
- **Bundle check:** `grep -rl "cdn.segment.com\|api.segment.io\|analytics-next\|Invalid path or write key" .next/static` → **zero matches**. Control: the same grep finds `sentry` in 258 files and `walletconnect` in 8, and `cdn.segment.com` does exist in `node_modules` — so the grep and chunks are sound.
- **Not done:** no dev server with the network panel open. The evidence is the bundle absence plus the source argument that settings are fetched only from `loadAnalytics`, reachable only via `.load()`.

## HotJar — checked, deliberately unchanged

#864 was titled "disable Segment **and HotJar**", so it was worth checking. HotJar is already genuinely inert: `hotjar.initialize()` is called nowhere in `src/`, `MonitorContext.tsx:137` guards on a pure `typeof window.hj === "function"` check, and the `console.warn` in `_app.tsx` is not captured (`captureConsoleIntegration` is `levels: ["error"]`). Leftovers are cosmetic — unused `config.hotjar`, the unused `react-hotjar` dep. Separate cleanup.

## Out of scope

`config.segmentWriteKey` and the `@segment/analytics-next` dependency both stay, since re-enabling tracking is still wanted. The stale `sentry.properties` project slug (`dashboard-v2` vs the live `superfluid-dashboard`), source-map linkage, and the `beforeSend` fan-out that cannot drop events are all recorded elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)