### PR TITLE
fix(wallet): probe the Safe connector before auto-connecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
     "replayio": "^1.8.2",
     "typescript": "^5.9.3"
   },
+  "pnpm": {
+    "overrides": {
+      "use-sync-external-store": "1.6.0"
+    }
+  },
   "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "engines": {
     "node": ">=20.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  use-sync-external-store: 1.6.0
+
 importers:
 
   .:
@@ -9845,16 +9848,6 @@ packages:
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
 
-  use-sync-external-store@1.2.0:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  use-sync-external-store@1.4.0:
-    resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -10528,7 +10521,7 @@ packages:
       '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
       react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
+      use-sync-external-store: 1.6.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -10546,7 +10539,7 @@ packages:
       '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
       react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
+      use-sync-external-store: 1.6.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -10564,7 +10557,7 @@ packages:
       '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
       react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
+      use-sync-external-store: 1.6.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -16244,22 +16237,6 @@ snapshots:
       porto: 0.2.35(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@3.6.2)(immer@10.2.0)(react-native@0.79.2(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.0.9)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.7.2)
       typescript: 5.9.3
 
-  '@wagmi/core@3.6.2(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.12.2)(immer@10.2.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
-      zustand: 5.0.0(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
-    optionalDependencies:
-      '@tanstack/query-core': 5.101.2
-      accounts: 0.12.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.79.2(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.0.9)(react@19.2.7)(utf-8-validate@5.0.10)))(@types/react@19.2.17)(@wagmi/core@3.6.2)(immer@10.2.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.7.2)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
   '@wagmi/core@3.6.2(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.12.2)(immer@10.2.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
@@ -19366,7 +19343,7 @@ snapshots:
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
       eslint-plugin-react: 7.37.5(eslint@9.39.5)
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5)
@@ -19399,7 +19376,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.7.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -19414,7 +19391,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24408,14 +24385,6 @@ snapshots:
 
   urlpattern-polyfill@8.0.2: {}
 
-  use-sync-external-store@1.2.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
-  use-sync-external-store@1.4.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -24469,7 +24438,7 @@ snapshots:
     dependencies:
       derive-valtio: 0.1.0(valtio@1.13.2(@types/react@19.2.17)(react@19.2.7))
       proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       react: 19.2.7
@@ -24624,9 +24593,9 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@wagmi/connectors': 8.0.23(jx7wbqjgpaih2szsadeedkyexu)
-      '@wagmi/core': 3.6.2(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.12.2)(immer@10.2.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.6.2(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.12.2)(immer@10.2.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.7
-      use-sync-external-store: 1.4.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
       viem: 2.55.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -25467,13 +25436,6 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
-
-  zustand@5.0.0(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7)):
-    optionalDependencies:
-      '@types/react': 19.2.17
-      immer: 10.2.0
-      react: 19.2.7
-      use-sync-external-store: 1.4.0(react@19.2.7)
 
   zustand@5.0.0(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:

--- a/src/features/wallet/useSafeAppAutoConnect.tsx
+++ b/src/features/wallet/useSafeAppAutoConnect.tsx
@@ -17,14 +17,26 @@ const useSafeAppAutoConnect = () => {
   }, [connectors]);
 
   useEffect(() => {
-    if (!isReconnecting && !isConnected && priorityConnectors.length > 0) {
-      const connector = priorityConnectors[0];
+    if (isReconnecting || isConnected) return;
 
-      if (connector) {
-        console.log(`Auto-connecting to ${connector.id} wallet`);
-        connect({ connector });
-      }
-    }
+    const connector = priorityConnectors[0];
+    if (!connector) return;
+
+    // Only connect when the connector actually has a provider. The Safe connector
+    // returns none outside of a Safe App iframe, and connecting anyway rejects and
+    // leaves wagmi reporting a storage-restored connector stub as "connected".
+    let cancelled = false;
+    void (async () => {
+      const provider = await connector.getProvider().catch(() => undefined);
+      if (cancelled || !provider) return;
+
+      console.log(`Auto-connecting to ${connector.id} wallet`);
+      connect({ connector });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [connect, isReconnecting, priorityConnectors]); // Don't include `isConnected` to avoid re-trying
 };
 


### PR DESCRIPTION
## The problem

`SUPERFLUID-DASHBOARD-FKF` — `TypeError: n.getProvider is not a function`. **3,749 events, 132 affected users**, first seen 2026-07-20, and **88% of its lifetime volume falls in the last 14 days** (~230/day, still climbing). With the Segment write-key noise removed in #883, this is the top genuine error in the app. Two siblings carry the same error fingerprinted separately (`-FNN`, `-FMM`).

## What actually causes it

`useSafeAppAutoConnect` fires a `connect()` that is **guaranteed to reject** for anyone not in an iframe, and wagmi's failure path then resurrects a localStorage connector stub as "connected":

1. `@wagmi/core@3.6.2/createConfig.js:169-182` — persist `partialize` writes each connection's connector as a plain stub `{ id, name, type, uid }`, plus `current`. Core acknowledges this: *"partial connectors in storage do not have it"* (`:374-376`).
2. `merge` (`:184-196`) deletes persisted `status` but restores `connections` (stubs) and `current`.
3. `useSafeAppAutoConnect.tsx:19-28` calls `connect({ connector: safe })` on mount whenever `!isReconnecting && !isConnected`. `isReconnecting` comes from AppKit state via `src/hooks/useAccount.ts`, not wagmi state, so it does not serialize against wagmi's `reconnectOnMount`.
4. `@wagmi/connectors@8.0.23/safe.js` — `getProvider()` returns `undefined` unless `window.parent !== window`; `connect()` throws `ProviderNotFoundError`. Deterministic for every top-level visitor.
5. `connect.js:46-52` catch: `status: x.current ? 'connected' : 'disconnected'`. With the hydrated non-null `current`, status flips to **`'connected'` while `connections` still holds the stub**. Nothing validates the stub is live.
6. `reconnect.js:83-96` cleanup is guarded on status still being `reconnecting`/`connecting` — the failed connect already moved it to `connected`, so the bad state **persists** rather than being momentary.
7. `@reown/appkit-adapter-wagmi@1.8.22/client.js:221` does `await connector.getProvider().catch(() => undefined)`. The stub has no `getProvider`, so it throws **synchronously** — `.catch()` never attaches — inside an async function invoked with no `await`/`catch` at `:159`. **Unhandled rejection**, matching the Sentry mechanism exactly.

The two different `@wagmi/core` pnpm hashes visible in one Sentry stack come from step 5→7: `connect()` runs from `wagmi`'s copy, `config.setState` belongs to the config object AppKit's copy built.

### A rejected theory, recorded so nobody re-runs it

The investigation started from the hypothesis that the **duplicate `@wagmi/core@3.6.2` instance** was the cause. Codex was asked to refute it and independently reached the same conclusion from the same evidence. It dies three times over: it **predates the error** (the same split existed at `ee1af4ff`, 2026-06-30, three weeks before first-seen); it **cannot strip methods** (`createConnector` is an identity function, `createConfig.setup` spreads the factory result, `connect` stores that same object reference — objects do not lose methods crossing a module boundary); and it is **not needed**, since every step above works inside a single copy.

## The fix

- **`useSafeAppAutoConnect.tsx`** — probe before connecting: only call `connect()` if the connector actually yields a provider, which is the precondition `safe.js` `getProvider` itself checks. Behaviour-preserving for real Safe App users, and it also covers non-Safe iframes, which a bare `window.parent !== window` gate would not. The Mock test connector returns `mockBridge`, so Cypress is unaffected.
- **`package.json`** — `pnpm.overrides: { "use-sync-external-store": "1.6.0" }`. **Hygiene, explicitly not the fix.** `wagmi@3.7.2` pins `1.4.0` exactly while root/appkit/`@lifi` all resolve `1.6.0`; that single divergence was splitting `@wagmi/core`.

## Verification

- `pnpm typecheck`, `pnpm lint` — clean.
- **Dedupe proven, not asserted:** lockfile `@wagmi/core@3.6.2(` entries **2 → 1**; only one `use-sync-external-store` (`1.6.0`) remains; `node_modules/.pnpm` holds exactly one `@wagmi+core@3.6.2_…` directory, hash `dwhyfewrsayafn35kt3oxe46fa` — one of the two from the Sentry stack, with `37pjxugjigjd53r5jv53skee4m` gone; `pnpm why @wagmi/core` resolves to a single `3.6.2`.

## Not verified — please check before merging

- **The crash was not reproduced.** It needs a returning user with a persisted wagmi `current` in localStorage, outside a Safe iframe. To confirm by hand: connect a wallet on app.superfluid.org, reload, watch for the unhandled rejection; then repeat against a preview build of this branch.
- **The Safe App path is untested.** This PR touches exactly that code — someone should load the dashboard inside a real Safe App and confirm auto-connect still fires.
- **No Cypress run.** The Mock connector is unaffected by the probe, but the wallet-connection features should be run.
- **Effect on volume** can only be confirmed by watching `-FKF`/`-FNN`/`-FMM` after deploy.

## Open question

The **2026-07-20** first-seen date is not explained by any code change in this repo. `connect.js`, `createConfig.js` and `reconnect.js` are byte-identical between `@wagmi/core` 3.5.5 (shipped 2026-06-30 in #871) and 3.6.2; `@reown/appkit-adapter-wagmi/client.js` is byte-identical between 1.8.20 and 1.8.22; the same `catch`/`partialize` logic exists in `@wagmi/core` v2. Two candidates: the v2→v3 bump versions the persist store by core's **major** (`createConfig.js:150-156`), wiping everyone's `connections` on deploy so the affected population rebuilt over the following days — or "first seen" is a fingerprint artifact, since three issues already carry this message. Settling it needs `firstRelease` for the three issues and a search for older *resolved* issues with the same message. **This does not affect the diagnosis or the fix**, both of which stand on the mechanism above.

## Worth reporting upstream (not done)

- `@wagmi/core`: `connect.js:46-52` resurrects `status: 'connected'` on failure without checking that `connections.get(current).connector` is a live connector rather than a storage stub; `reconnect.js:83-96` then skips its own cleanup because status is no longer `reconnecting`.
- `@reown/appkit-adapter-wagmi`: `client.js:221` calls `connector.getProvider()` unguarded and `:159` invokes the async `handleAccountChanged` with no `catch`. Still unguarded in 1.8.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)