### PR TITLE
fix(wallet): don't render an unresolved wallet as an empty transaction list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/dashboard",
-  "version": "66.0.0",
+  "version": "67.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/WalletWeirdnessHandler/WalletWeirdnessHandler.tsx
+++ b/src/components/WalletWeirdnessHandler/WalletWeirdnessHandler.tsx
@@ -1,7 +1,25 @@
 import { useEthersSigner } from "@/utils/wagmiEthersAdapters"
 import { useAppKitAccount, useAppKitNetwork, useAppKitState, useDisconnect as useAppKitDisconnect } from "@reown/appkit/react"
+import * as Sentry from "@sentry/react"
 import { useEffect, useState } from "react"
 import { useAccount as useWagmiAccount, useDisconnect as useWagmiDisconnect } from "wagmi"
+
+type WeirdnessKind = "confused-connection" | "chain-disagreement" | "address-disagreement" | "missing-signer"
+
+// The handler disconnects the user, which is drastic, and it does so on heuristics
+// with second-scale timeouts. Report each trigger so the rate is measurable rather
+// than guessed at. The message is kept constant per kind — anything variable goes in
+// `extra`, so Sentry fingerprints these as four issues with counts instead of one
+// issue per address. `console.warn` is not captured by the console integration
+// (`levels: ["error"]`), so this has to be an explicit call.
+function reportWeirdness(kind: WeirdnessKind, message: string, extra?: Record<string, unknown>) {
+    console.warn(message, extra)
+    Sentry.captureMessage(`WalletWeirdnessHandler disconnected the wallet: ${kind}`, {
+        level: "warning",
+        tags: { wallet_weirdness: kind },
+        extra,
+    })
+}
 
 export function WalletWeirdnessHandler() {
     const { address: wagmiAddress, chainId: wagmiChainId } = useWagmiAccount()
@@ -31,7 +49,10 @@ export function WalletWeirdnessHandler() {
             const isAppKitConfusedAboutBeingConnected = appKitIsConnected && appkitStatus === "disconnected"
             if (isAppKitConfusedAboutBeingConnected) {
                 const timeout = setTimeout(() => {
-                    console.warn("AppKit's internal connection state is confused about connection status. Disconnecting...")
+                    reportWeirdness("confused-connection", "AppKit's internal connection state is confused about connection status. Disconnecting...", {
+                        appkitStatus,
+                        appKitIsConnected,
+                    })
                     appKitDisconnect()
                     wagmiDisconnect()
                     setHasBeenHandledOnce(true)
@@ -41,7 +62,10 @@ export function WalletWeirdnessHandler() {
             if (appKitIsConnected) {
                 if (wagmiChainId !== appkitChainId) {
                     const timeout = setTimeout(() => {
-                        console.warn("AppKit's internal chain state is confused. AppKit and Wagmi disagree about the chain ID. Disconnecting...")
+                        reportWeirdness("chain-disagreement", "AppKit's internal chain state is confused. AppKit and Wagmi disagree about the chain ID. Disconnecting...", {
+                            appkitChainId,
+                            wagmiChainId,
+                        })
                         appKitDisconnect()
                         wagmiDisconnect()
                         setHasBeenHandledOnce(true)
@@ -54,7 +78,10 @@ export function WalletWeirdnessHandler() {
                     // session until they refresh. Both addresses move within a tick on a
                     // normal account switch, so a disagreement this long is a real one.
                     const timeout = setTimeout(() => {
-                        console.warn(`AppKit's internal account state is confused. AppKit and Wagmi disagree about the address (AppKit: ${accountAddress}, Wagmi: ${wagmiAddress}). Disconnecting...`)
+                        reportWeirdness("address-disagreement", `AppKit's internal account state is confused. AppKit and Wagmi disagree about the address (AppKit: ${accountAddress}, Wagmi: ${wagmiAddress}). Disconnecting...`, {
+                            appkitAddress: accountAddress,
+                            wagmiAddress,
+                        })
                         appKitDisconnect()
                         wagmiDisconnect()
                         setHasBeenHandledOnce(true)
@@ -64,7 +91,10 @@ export function WalletWeirdnessHandler() {
             }
             if (accountAddress && !signer) {
                 const timeout = setTimeout(() => {
-                    console.warn("AppKit's internal state is unable to get the signer. Disconnecting...")
+                    reportWeirdness("missing-signer", "AppKit's internal state is unable to get the signer. Disconnecting...", {
+                        wagmiChainId,
+                        hasWagmiAddress: Boolean(wagmiAddress),
+                    })
                     appKitDisconnect()
                     wagmiDisconnect()
                     setHasBeenHandledOnce(true)

--- a/src/components/WalletWeirdnessHandler/WalletWeirdnessHandler.tsx
+++ b/src/components/WalletWeirdnessHandler/WalletWeirdnessHandler.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { useAccount as useWagmiAccount, useDisconnect as useWagmiDisconnect } from "wagmi"
 
 export function WalletWeirdnessHandler() {
-    const { chainId: wagmiChainId } = useWagmiAccount()
+    const { address: wagmiAddress, chainId: wagmiChainId } = useWagmiAccount()
     const { chainId: appkitChainId } = useAppKitNetwork()
 
     const { disconnect: wagmiDisconnect } = useWagmiDisconnect()
@@ -13,7 +13,7 @@ export function WalletWeirdnessHandler() {
     const { address: accountAddress, status: appkitStatus, isConnected: appKitIsConnected } = useAppKitAccount()
     const appKitState = useAppKitState()
 
-    const isAppKitDoingSomething = !appKitState.initialized && !appKitState.loading && !(appkitStatus === "connecting" || appkitStatus === "reconnecting")
+    const isAppKitDoingSomething = !appKitState.initialized || appKitState.loading || appkitStatus === "connecting" || appkitStatus === "reconnecting"
 
     const doesAppKitThinkItIsReady = !isAppKitDoingSomething
 
@@ -48,6 +48,19 @@ export function WalletWeirdnessHandler() {
                     }, 3000)
                     return () => clearTimeout(timeout)
                 }
+                if (accountAddress && wagmiAddress && accountAddress.toLowerCase() !== wagmiAddress.toLowerCase()) {
+                    // Longer than the checks above: disconnecting is total and latches
+                    // via `hasBeenHandledOnce`, so a false positive costs the user their
+                    // session until they refresh. Both addresses move within a tick on a
+                    // normal account switch, so a disagreement this long is a real one.
+                    const timeout = setTimeout(() => {
+                        console.warn(`AppKit's internal account state is confused. AppKit and Wagmi disagree about the address (AppKit: ${accountAddress}, Wagmi: ${wagmiAddress}). Disconnecting...`)
+                        appKitDisconnect()
+                        wagmiDisconnect()
+                        setHasBeenHandledOnce(true)
+                    }, 5000)
+                    return () => clearTimeout(timeout)
+                }
             }
             if (accountAddress && !signer) {
                 const timeout = setTimeout(() => {
@@ -59,7 +72,7 @@ export function WalletWeirdnessHandler() {
                 return () => clearTimeout(timeout)
             }
         }
-    }, [doesAppKitThinkItIsReady, appKitDisconnect, wagmiDisconnect, appKitIsConnected, appkitStatus, appkitChainId, wagmiChainId, signer])
+    }, [doesAppKitThinkItIsReady, appKitDisconnect, wagmiDisconnect, appKitIsConnected, appkitStatus, appkitChainId, wagmiChainId, signer, accountAddress, wagmiAddress])
 
     return null
 }

--- a/src/features/transactionDrawer/TransactionList.tsx
+++ b/src/features/transactionDrawer/TransactionList.tsx
@@ -1,24 +1,98 @@
-import { Divider, List } from "@mui/material";
-import { Fragment, memo } from "react";
+import {
+  Divider,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Skeleton,
+} from "@mui/material";
+import { FC, Fragment, memo } from "react";
 import TransactionListItem from "./TransactionListItem";
 import {
   useAccountTransactionsSelector,
   transactionsByTimestampSelector,
 } from "../wallet/useAccountTransactions";
+import { useAccount } from "@/hooks/useAccount";
+
+// Deliberately not the project-wide `loading-skeletons` hook: this drawer is
+// mounted on every page (persistent variant), and that hook is asserted
+// globally in Cypress.
+const TransactionListItemSkeleton = () => (
+  <ListItem data-cy={"transaction-list-skeletons"} aria-hidden>
+    <ListItemAvatar>
+      <Skeleton variant="circular" width={28} height={28} />
+    </ListItemAvatar>
+    <ListItemText
+      primary={<Skeleton variant="text" width={160} />}
+      secondary={<Skeleton variant="text" width={120} />}
+    />
+  </ListItem>
+);
+
+const TransactionListMessage: FC<{ dataCy: string; message: string }> = ({
+  dataCy,
+  message,
+}) => (
+  <ListItem>
+    <ListItemText
+      data-cy={dataCy}
+      translate="yes"
+      primary={message}
+      slotProps={{
+        primary: {
+          align: "center",
+          color: "text.secondary",
+        },
+      }}
+    />
+  </ListItem>
+);
 
 export default memo(function TransactionList() {
-  const transactions = useAccountTransactionsSelector(
+  const { transactions, isResolving } = useAccountTransactionsSelector(
     transactionsByTimestampSelector
   );
+  const { address: accountAddress } = useAccount();
+
+  // The wallet stack hasn't settled yet (AppKit still reports no address while
+  // connecting), so we don't know the account's transactions — showing an empty
+  // list here would read as "you have none".
+  if (isResolving) {
+    return (
+      <List disablePadding aria-busy>
+        {[0, 1, 2].map((index) => (
+          <Fragment key={index}>
+            <TransactionListItemSkeleton />
+            <Divider component="li" />
+          </Fragment>
+        ))}
+      </List>
+    );
+  }
 
   return (
     <List disablePadding>
-      {transactions.map((transaction) => (
-        <Fragment key={transaction.hash}>
-          <TransactionListItem transaction={transaction} />
-          <Divider component="li" />
-        </Fragment>
-      ))}
+      {transactions.length > 0 ? (
+        transactions.map((transaction) => (
+          <Fragment key={transaction.hash}>
+            <TransactionListItem transaction={transaction} />
+            <Divider component="li" />
+          </Fragment>
+        ))
+      ) : accountAddress ? (
+        <TransactionListMessage
+          dataCy="no-transactions-message"
+          message="No transactions yet"
+        />
+      ) : (
+        // The drawer can outlive a disconnect — its open state lives in the
+        // layout context — so don't claim an account has no transactions when
+        // there is no account.
+        <TransactionListMessage
+          dataCy="no-account-message"
+          message="Connect a wallet to see your transactions"
+        />
+      )}
     </List>
   );
 });

--- a/src/features/transactions/TransactionBell.tsx
+++ b/src/features/transactions/TransactionBell.tsx
@@ -26,7 +26,7 @@ export default memo(function TransactionBell() {
   const { transactionDrawerOpen, setTransactionDrawerOpen } =
     useLayoutContext();
 
-  const pendingTransactions = useAccountTransactionsSelector(
+  const { transactions: pendingTransactions } = useAccountTransactionsSelector(
     pendingTransactionsSelector
   );
 

--- a/src/features/wallet/useAccountTransactions.tsx
+++ b/src/features/wallet/useAccountTransactions.tsx
@@ -21,19 +21,25 @@ export const transactionByHashSelector =
 
 export const useAccountTransactionsSelector = <T,>(
   postProcess: (transactions: Array<TrackedTransaction>) => T
-): T => {
-  const accountTransactions = useAccountTransactions();
+): { transactions: T; isResolving: boolean } => {
+  const { transactions, isResolving } = useAccountTransactions();
 
   const finalTransactions = useMemo(
-    () => postProcess(accountTransactions),
-    [accountTransactions, postProcess]
+    () => postProcess(transactions),
+    [transactions, postProcess]
   );
 
-  return finalTransactions;
+  return useMemo(
+    () => ({ transactions: finalTransactions, isResolving }),
+    [finalTransactions, isResolving]
+  );
 };
 
-const useAccountTransactions = (): Array<TrackedTransaction> => {
-  const { address: accountAddress } = useAccount();
+const useAccountTransactions = (): {
+  transactions: Array<TrackedTransaction>;
+  isResolving: boolean;
+} => {
+  const { address: accountAddress, isConnecting, isReconnecting } = useAccount();
 
   const allTransactions = useAppSelector(transactionTrackerSelectors.selectAll);
 
@@ -45,7 +51,18 @@ const useAccountTransactions = (): Array<TrackedTransaction> => {
     [allTransactions, accountAddress]
   );
 
-  return accountTransactions;
+  // On a hard refresh AppKit lags behind wagmi: it reports `connecting` with no
+  // address yet. Without this flag consumers can't tell "we don't know the
+  // account yet" from "the account has no transactions", and an unresolved
+  // wallet renders as a settled empty list.
+  // (`isReconnecting` is included defensively — AppKit types the status but
+  // never actually assigns it, so `isConnecting` is what carries this today.)
+  const isResolving = !accountAddress && (isConnecting || isReconnecting);
+
+  return useMemo(
+    () => ({ transactions: accountTransactions, isResolving }),
+    [accountTransactions, isResolving]
+  );
 };
 
 export default useAccountTransactions;


### PR DESCRIPTION
## The problem

Reported in #819: on a hard refresh with an existing wallet session, the transaction drawer is empty for a moment, then populates.

wagmi restores the connection immediately; AppKit goes through `connecting` with `address === undefined`. `useAccount` (`src/hooks/useAccount.ts:9`) sources `address` from AppKit, so during that window it's undefined and `useAccountTransactions` did:

```ts
accountAddress ? allTransactions.filter(...) : []
```

The `[]` renders as a blank `<List>` — visually identical to "you have no transactions". The drawer had no empty-state copy at all, so there was nothing to distinguish the two.

So the actual defect isn't a wrong address. It's that **"unknown yet" was rendered as "known empty."**

## Why not fall back to wagmi's address

#866 proposed fixing this in `useAccount` with `appKitAddress ?? wagmiAddress`. The diagnosis there is correct — `signerAddress` on tracked transactions is written from the wagmi-derived ethers signer (`ReduxProvider.tsx:53-61`), so wagmi is the consistent comparison basis for *that filter*. But the placement isn't:

- `useAccount` has 42 consumers. `VisibleAddressContext.tsx:32-33` derives `visibleAddress` from `address` with no `isConnected` check, so this changes when the *whole dashboard* starts rendering account data, not just the drawer.
- It creates a state that couldn't previously exist: `address` defined while `isConnected === false` (`isConnected` stays AppKit-owned at `useAccount.ts:39`). `ConnectionBoundary.tsx:45` gates transaction buttons on `isConnected` while `TransactionBoundary.tsx:55` and others key off `address` alone — the two would disagree for the duration of the reconnect.
- `wagmiConfig.ts:194` sets `ssr: false` with localStorage storage (`:197`), so wagmi rehydrates the **previous address from storage while it is still reconnecting**. (I did not trace wagmi's rehydration internals to confirm exactly how early that address is exposed — worth checking if this bullet is load-bearing for anyone.) If the reconnect then fails (locked wallet, revoked permission), the app has already rendered and fetched for an address that never connected this session.
- `ImpersonationContext.tsx:161-171` auto-stops impersonation when the connected address matches the impersonated one. With the fallback, a hard refresh of `?view=<own-address>` kills impersonation and rewrites the URL seconds before the wallet has actually reconnected.

## The fix

Wait for the wallet stack to settle, using the readiness signal `useAccount` already exports. This is an established idiom in the codebase — `pages/token/[_network]/[_token].tsx:103` guards a redirect on `isConnecting || isReconnecting` for exactly this reason, and `ConnectWallet.tsx:157` shows a loading state on `isReconnecting`.

- **`useAccountTransactions.tsx`** — returns `{ transactions, isResolving }` where `isResolving = !address && (isConnecting || isReconnecting)`. `useAccountTransactionsSelector` threads it through; `postProcess` still applies only to the transactions.
- **`TransactionList.tsx`** — skeletons while resolving. Adds the missing empty state, split two ways: "No transactions yet" when an account is connected, "Connect a wallet to see your transactions" when there is none. The drawer's open state lives in `LayoutContext` and is never cleared on disconnect, so an already-open drawer outlives a disconnect — telling that user they have no transactions would be the same bug one level up.
- **`TransactionBell.tsx`** — destructure only. No `isResolving` guard: `isResolving` implies no address, and the component already returns `null` in that case (`:33`), so a guard would be dead code.

`useAccount.ts` is deliberately untouched.

### Two unrelated bugs found on the way, in `WalletWeirdnessHandler`

Both are in the watchdog that force-disconnects when AppKit and wagmi desync. Folded in here because the second one is what makes reasoning about this class of bug unreliable.

**1. The readiness gate never detected busyness** (`:16`):

```ts
// before — true in exactly one state: uninitialized and idle
!initialized && !loading && !(connecting || reconnecting)
// after — true whenever AppKit is uninitialized or busy
!initialized || loading || connecting || reconnecting
// (abbreviated: the code reads appKitState.initialized / .loading and
//  compares appkitStatus === "connecting" | "reconnecting")
```

Not an inversion — with `busy = loading || connecting || reconnecting`, the old form is `!init && !busy` and the new one is `!init || busy`; they agree whenever AppKit is idle and differ whenever it is busy. The bug is narrower and worse than a sign error: the old expression was **false in every busy state**, so `isAppKitDoingSomething` never detected the thing it is named for. Its one true case, uninitialized-and-idle, is a genuine not-ready state, so the name was fine.

Negated into `doesAppKitThinkItIsReady`, that means "ready" held throughout connection flows, so the disconnect watchdogs armed *during* them and were saved only by their 1s/3s timers. Verified against the installed `@reown/appkit@1.8.22`: `PublicStateController.set({initialized: true})` runs at `appkit.js:419`, after `syncExistingConnection()` — so on a hard-refresh reconnect the old gate read "ready" in exactly the window where the two stacks are known to disagree.

**2. The address-mismatch check didn't exist.** The file compared chain IDs (`:42`) and checked whether an AppKit address had *some* wagmi signer (`:52`) — but that signer comes from wagmi's own connector client (`wagmiEthersAdapters.ts:54-63`), so it's truthy whichever address wagmi holds and can never detect a mismatch. Added the real check in the same debounced style, at 5s rather than the neighbours' 3s: disconnecting is total and latches via `hasBeenHandledOnce`, so a false positive costs the user their session until they refresh. AppKit's own address update is synchronous once its account handler fires — `syncAccount` (`appkit-base-client.js:1313`) reaches `setCaipAddress` (`:1381`) with no intervening await — and wagmi reacts to the same connector event, so a disagreement that survives 5s is not the normal switch path. Both addresses are in the effect's dep array, so the timer tears down the instant either side moves.

## Verification

- `pnpm typecheck`, `pnpm lint` — clean.
- Reviewed adversarially; several findings from that pass are folded in: the skeleton uses `data-cy="transaction-list-skeletons"` rather than the project-wide `loading-skeletons` hook, because this drawer is `variant="persistent"` and therefore mounted in the DOM on every desktop page, while `DashboardPage.ts:85-86` asserts `doesNotExist(LOADING_SKELETONS)` against a DOM-global selector (`:16`) — inside `waitForBalancesToLoad()`, not on every page, but that is called widely enough for a shared `data-cy` to collide. Also added `aria-busy` / `aria-hidden` on the loading state, and the mismatch warning now logs both addresses.
- Hydration checked: `TransactionDrawer` wraps the list in `ReduxPersistGate`, which renders `null` until `componentDidMount`, so `isResolving` never participates in the server/first-client render. Note this safety comes from the gate, not from this diff — `useAccount` returns `isConnecting`/`isReconnecting` ungated by its `mounted` flag while gating `address`. If `TransactionList` ever moves out of the gate, that becomes a mismatch.
- Memoization verified: both selector callbacks are module-level constants, and the added `useMemo` layers preserve referential stability, so the `memo()` on both consumers still holds.

## Not verified — please check before merging

- **The original bug was not reproduced against this branch.** It needs a returning user with a persisted session and AppKit lagging on refresh. Worth confirming by hand on a preview deploy: connect, hard-refresh, open the drawer.
- **Two connected wallets, switched from AppKit's account modal.** AppKit 1.8 tracks connections per namespace and wagmi v3 tracks its own `current` independently. If those can legitimately diverge, the new mismatch check would force-disconnect after 5s with no in-session recovery. I found no code path proving they diverge and none proving they can't — this is the one thing I'd manually test: connect two wallets, switch between them in the modal, wait ~10s.
- **No Cypress run.** The suite can't simulate the AppKit/wagmi rehydration race (all specs connect explicitly through the mock connector first), so nothing here is covered by CI either before or after. There are no unit tests for these hooks.

## Known limitation, not addressed

`reconnectWalletConnect()` (`appkit-base-client.js:1142`) is awaited with no deadline at `:1171`, inside `syncNamespaceConnection` — which has already set status `connecting` at `:1168`. If the WC relay hangs, AppKit stays `connecting` forever — which now means both indefinite skeletons in the drawer *and* permanently disarmed watchdogs. Previously the watchdogs would eventually fire. A max-arming-delay (arm regardless of status after N seconds) would cover both, but it's a behaviour change of its own and doesn't belong in this PR.

## Follow-ups worth filing

- `ImpersonationContext.tsx:161-171` should gate its auto-stop on `isConnected`. Currently safe only because `useAccount` is AppKit-strict; it becomes a footgun the moment anyone re-attempts a wagmi fallback.
- The chain-ID comparison in `WalletWeirdnessHandler.tsx` (`:42` before this PR, `:63` after) tests `wagmiChainId !== appkitChainId`, but `useAppKitNetwork().chainId` is typed `number | string | undefined` against wagmi's `number | undefined`. A string chain ID would make that comparison always true — a false-positive disconnect. TypeScript doesn't flag it because the union overlaps on `number`.
- `transactionByHashSelector` (`useAccountTransactions.tsx:17`) has zero consumers, and is the one selector shape that would break the new memoization contract if used.

Supersedes #866. The diagnosis there was right and worth crediting — thanks @mike-diamond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

