### PR TITLE
fix(wallet): anchor the Safe Apps allowed-domain patterns

### DIFF
--- a/src/features/wallet/wagmiConfig.ts
+++ b/src/features/wallet/wagmiConfig.ts
@@ -198,9 +198,15 @@ const wagmiAdapter = new WagmiAdapter({
   storage: typeof window !== "undefined" ? createStorage({ storage: window.localStorage }) : undefined,
   connectors: [
     safe({
+      // These are matched against `event.origin` of the parent frame and decide whose
+      // messages the Safe Apps SDK will trust (`PostMessageCommunicator.isValidMessage`).
+      // Anchor and escape every pattern: an unanchored `/app.safe.global$/` also admits
+      // `https://appXsafeYglobal`, and an unanchored `/gnosis-safe.io$/` also admits
+      // `https://evilgnosis-safe.io` — both attacker-registrable. Follow the shape the
+      // coinshift entry already uses.
       allowedDomains: [
-        /gnosis-safe.io$/,
-        /app.safe.global$/,
+        /^https:\/\/(?:[^\/]+\.)?gnosis-safe\.io$/,
+        /^https:\/\/(?:[^\/]+\.)?app\.safe\.global$/,
         /^https:\/\/(?:[^\/]+\.)?coinshift\.xyz$/,
         /^http:\/\/(localhost|127\.0\.0\.1):(\d+)$/,
       ],


### PR DESCRIPTION
## What

`allowedDomains` in `wagmiConfig.ts` decides whose parent-frame messages the Safe Apps SDK will trust — `PostMessageCommunicator.isValidMessage` admits a message when **any** pattern matches `event.origin` (`@safe-global/safe-apps-sdk/dist/cjs/communication/index.js:30-32`).

Two of the four patterns were neither anchored nor had their dots escaped, so they matched on **suffix**:

```
/gnosis-safe.io$/    also admits  https://evilgnosis-safe.io
/app.safe.global$/   also admits  https://appXsafeYglobal
```

Both are attacker-registrable domains. A page served from one could embed the dashboard in an iframe and impersonate the Safe host to it, supplying fabricated account, chain and transaction responses.

The other two entries (`coinshift.xyz`, localhost) were already anchored and escaped correctly. This change brings the first two into the same shape.

## Verification

No unit-test framework exists on `master`, so this was verified by running the before/after patterns directly against a case matrix rather than by adding a test file (introducing vitest here would also collide with #872, which already does):

| origin | before | after | intended |
|---|---|---|---|
| `https://app.safe.global` | ✅ | ✅ | admit |
| `https://staging.app.safe.global` | ✅ | ✅ | admit |
| `https://gnosis-safe.io` | ✅ | ✅ | admit |
| `https://app.gnosis-safe.io` | ✅ | ✅ | admit |
| `https://app.coinshift.xyz` | ✅ | ✅ | admit |
| `http://localhost:3000` | ✅ | ✅ | admit |
| `https://evilgnosis-safe.io` | ⚠️ **admitted** | ❌ | reject |
| `https://appXsafeYglobal` | ⚠️ **admitted** | ❌ | reject |
| `http://app.safe.global` | ⚠️ **admitted** | ❌ | reject |
| `https://app.safe.global.evil.com` | ❌ | ❌ | reject |
| `https://evil.com` | ❌ | ❌ | reject |

Every legitimate origin is still admitted — this is a tightening with no intended-behaviour change. Plaintext `http://app.safe.global` is newly rejected, which is deliberate.

`pnpm typecheck` clean. Note that ESLint currently reports `wagmiConfig.ts` as *"File ignored because no matching configuration was supplied"*, so this file has no lint coverage — unchanged by this PR, but worth knowing.

## How this was found

Fallout from an adversarial review of a separate, unmerged plan to enable Clear Macro gasless relay for Safes. This bug is **independent of that work and live on `master` today**, which is why it is its own PR. It does become load-bearing once the Safe Apps SDK is trusted for transaction authorization, hence fixing it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)