### PR TITLE
feat(approvals): honor the app's network selection

### DIFF
--- a/src/features/tokenAccess/TokenAccessTables.tsx
+++ b/src/features/tokenAccess/TokenAccessTables.tsx
@@ -1,12 +1,15 @@
 import {
+  Button,
   Stack,
   Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { FC, useCallback, useMemo, useState } from "react";
+import { FC, useCallback, useMemo, useRef, useState } from "react";
 import { TokenAccessTable } from "./TokenAccessTable";
-import { useAvailableNetworks } from "../network/AvailableNetworksContext";
+import OpenIcon from "../../components/OpenIcon/OpenIcon";
+import { useActiveNetworks } from "../network/ActiveNetworksContext";
+import NetworkSelectionFilter from "../network/NetworkSelectionFilter";
 import { UpsertTokenAccessButton } from "./TokenAccessRow";
 import { useVisibleAddress } from "../wallet/VisibleAddressContext";
 import { useExpectedNetwork } from "../network/ExpectedNetworkContext";
@@ -35,15 +38,14 @@ export function TokenAccessTables() {
   const theme = useTheme();
   const isBelowMd = useMediaQuery(theme.breakpoints.down("md"));
 
-  const { availableNetworks: availableNetworks_ } = useAvailableNetworks();
+  const { activeNetworks } = useActiveNetworks();
   const { network: expectedNetwork } = useExpectedNetwork();
-  const availableNetworks = useMemo(
-    () => [
-      ...availableNetworks_.filter((x) => x === expectedNetwork), // Order the current network first.
-      ...availableNetworks_.filter((x) => x !== expectedNetwork),
-    ],
-    [availableNetworks_, expectedNetwork]
-  );
+
+  const networkSelectionRef = useRef<HTMLButtonElement>(null);
+  const [networkSelectionOpen, setNetworkSelectionOpen] = useState(false);
+
+  const openNetworkSelection = () => setNetworkSelectionOpen(true);
+  const closeNetworkSelection = () => setNetworkSelectionOpen(false);
 
   const [fetchingStatuses, setFetchingStatuses] =
     useState<NetworkFetchingStatuses>({});
@@ -59,18 +61,18 @@ export function TokenAccessTables() {
 
   const hasContent = useMemo(
     () =>
-      availableNetworks.some(
+      activeNetworks.some(
         (network) => fetchingStatuses[network.id]?.hasContent
       ),
-    [availableNetworks, fetchingStatuses]
+    [activeNetworks, fetchingStatuses]
   );
 
   const isLoading = useMemo(
     () =>
-      availableNetworks.some(
+      activeNetworks.some(
         (network) => fetchingStatuses[network.id]?.isLoading !== false
       ),
-    [availableNetworks, fetchingStatuses]
+    [activeNetworks, fetchingStatuses]
   );
 
   const showEmptyCard = !hasContent && !isLoading;
@@ -91,16 +93,35 @@ export function TokenAccessTables() {
             Manage your Super Token permissions and allowances in one place.
           </Typography>
         </Stack>
-        <UpsertTokenAccessButton
-          dataCy={"token-access-global-button"}
-          initialFormValues={{
-            network: expectedNetwork,
-          }}
-        />
+        <Stack direction="row" sx={{
+          gap: 1.5
+        }}>
+          <UpsertTokenAccessButton
+            dataCy={"token-access-global-button"}
+            initialFormValues={{
+              network: expectedNetwork,
+            }}
+          />
+          <Button
+            data-cy={"network-selection-button"}
+            ref={networkSelectionRef}
+            variant="outlined"
+            color="secondary"
+            endIcon={<OpenIcon open={networkSelectionOpen} />}
+            onClick={openNetworkSelection}
+          >
+            All networks
+          </Button>
+          <NetworkSelectionFilter
+            open={networkSelectionOpen}
+            anchorEl={networkSelectionRef.current}
+            onClose={closeNetworkSelection}
+          />
+        </Stack>
       </Stack>
       {showEmptyCard && <EmptyCard />}
       {
-        visibleAddress && availableNetworks.map((network) => (
+        visibleAddress && activeNetworks.map((network) => (
           <TokenAccessTable
             key={`${network.id}-${visibleAddress}`}
             address={visibleAddress!}


### PR DESCRIPTION
Make the Approvals page respect the app's network selection, for consistency with the rest of the app.

The Approvals page was the only network-table page mapping over the raw `allNetworks` list: no testnet-mode filtering, no hidden-network preference, no selection UI, and a subgraph query fired for all 15 networks on every visit. Git archaeology says this was accidental, not designed: it's been that way since the file's creation in #599 with no recorded intent, and the same author built the structurally identical auto-wrap tables two weeks later (#617) with the proper `useActiveNetworks` + `NetworkSelectionFilter` wiring.

This ports that same pattern: consume `useActiveNetworks()` (which also orders the expected network first, replacing the hand-rolled memo) and add the "All networks" button opening `NetworkSelectionFilter`, matching dashboard, history and auto-wrap.

Notes for reviewers:

- No Cypress scenario depends on the old unfiltered behaviour — every approvals assertion targets a named network's table, and cross-network scenarios stay within one testnet class.
- Once this lands, the Approvals carve-out paragraph in `degenExclusion.ts` on #886 (`fix/cypress-suite-repair`) becomes stale — its `hidden` seed then covers Approvals for free. Worth a small follow-up on that branch.
- No overlap with #890 or #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)